### PR TITLE
Replace suggestions table with searchable source directory

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -210,22 +210,30 @@ open ./build/StatusBar.app</code></pre>
             <img src="screenshots/settings.png" alt="Settings view showing source management and preferences" class="screenshot">
           </div>
           <div class="doc-content">
-            <p class="doc-desc">Open Settings and click <strong>+</strong> to add any <a href="https://www.atlassian.com/software/statuspage">Atlassian Statuspage</a>-powered service by name and URL. Import and export source lists as TSV files to share between machines.</p>
-            <table class="doc-table">
-              <thead>
-                <tr><th>Service</th><th>URL</th></tr>
-              </thead>
-              <tbody>
-                <tr><td>Anthropic / Claude</td><td><code>https://status.anthropic.com</code></td></tr>
-                <tr><td>GitHub</td><td><code>https://www.githubstatus.com</code></td></tr>
-                <tr><td>Cloudflare</td><td><code>https://www.cloudflarestatus.com</code></td></tr>
-                <tr><td>Atlassian</td><td><code>https://status.atlassian.com</code></td></tr>
-                <tr><td>Datadog</td><td><code>https://status.datadoghq.com</code></td></tr>
-                <tr><td>Vercel</td><td><code>https://www.vercel-status.com</code></td></tr>
-                <tr><td>Linear</td><td><code>https://linearstatus.com</code></td></tr>
-                <tr><td>Notion</td><td><code>https://status.notion.so</code></td></tr>
-              </tbody>
-            </table>
+            <p class="doc-desc">Open Settings and click <strong>+</strong> to add any <a href="https://www.atlassian.com/software/statuspage">Atlassian Statuspage</a>-powered service by name and URL, or import a TSV file to add many at once.</p>
+            <p class="doc-desc doc-desc-hint">Select services below, export as TSV, then import the file in StatusBar via Settings&nbsp;&rarr;&nbsp;Import.</p>
+          </div>
+        </div>
+        <div class="source-directory">
+          <div class="source-toolbar">
+            <input type="search" id="source-search" class="source-search"
+              placeholder="Search services or URLs..." aria-label="Filter status page sources" autocomplete="off">
+            <span class="source-count" id="source-count"></span>
+          </div>
+          <div class="source-list" id="source-list" role="list"></div>
+          <div class="source-actions">
+            <label class="source-select-all" id="source-select-all-label">
+              <input type="checkbox" id="source-select-all">
+              <span class="source-select-check">
+                <svg class="check-icon" width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="#fff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 5l2.5 2.5L8 3"/></svg>
+                <svg class="minus-icon" width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="#fff" stroke-width="1.5" stroke-linecap="round"><line x1="2.5" y1="5" x2="7.5" y2="5"/></svg>
+              </span>
+              Select all
+            </label>
+            <button class="btn btn-primary source-export-btn" id="source-export" disabled>
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v8m0 0L5 7m3 3 3-3M3 12h10"/></svg>
+              Export TSV
+            </button>
           </div>
         </div>
       </div>

--- a/docs/script.js
+++ b/docs/script.js
@@ -62,6 +62,277 @@
     });
   }
 
+  // --- Source Directory ---
+  var STATUS_SOURCES = [
+    // AI & Technology
+    { name: 'Anthropic', url: 'https://status.anthropic.com', category: 'AI & Technology' },
+    { name: 'OpenAI', url: 'https://status.openai.com', category: 'AI & Technology' },
+    { name: 'Hugging Face', url: 'https://status.huggingface.co', category: 'AI & Technology' },
+    { name: 'Stability AI', url: 'https://status.stability.ai', category: 'AI & Technology' },
+    { name: 'Perplexity', url: 'https://status.perplexity.ai', category: 'AI & Technology' },
+    { name: 'Cohere', url: 'https://status.cohere.com', category: 'AI & Technology' },
+    { name: 'Mistral', url: 'https://status.mistral.ai', category: 'AI & Technology' },
+    // Developer Platforms
+    { name: 'GitHub', url: 'https://www.githubstatus.com', category: 'Developer Platforms' },
+    { name: 'Atlassian', url: 'https://status.atlassian.com', category: 'Developer Platforms' },
+    { name: 'Bitbucket', url: 'https://bitbucket.status.atlassian.com', category: 'Developer Platforms' },
+    { name: 'GitLab', url: 'https://status.gitlab.com', category: 'Developer Platforms' },
+    { name: 'Linear', url: 'https://linearstatus.com', category: 'Developer Platforms' },
+    { name: 'Vercel', url: 'https://www.vercel-status.com', category: 'Developer Platforms' },
+    { name: 'Netlify', url: 'https://www.netlifystatus.com', category: 'Developer Platforms' },
+    { name: 'Render', url: 'https://status.render.com', category: 'Developer Platforms' },
+    { name: 'Railway', url: 'https://status.railway.com', category: 'Developer Platforms' },
+    { name: 'Fly.io', url: 'https://status.flyio.net', category: 'Developer Platforms' },
+    { name: 'Heroku', url: 'https://status.heroku.com', category: 'Developer Platforms' },
+    { name: 'npm', url: 'https://status.npmjs.org', category: 'Developer Platforms' },
+    { name: 'CircleCI', url: 'https://status.circleci.com', category: 'Developer Platforms' },
+    { name: 'Codecov', url: 'https://status.codecov.io', category: 'Developer Platforms' },
+    // Cloud & CDN
+    { name: 'Cloudflare', url: 'https://www.cloudflarestatus.com', category: 'Cloud & CDN' },
+    { name: 'Fastly', url: 'https://status.fastly.com', category: 'Cloud & CDN' },
+    { name: 'DigitalOcean', url: 'https://status.digitalocean.com', category: 'Cloud & CDN' },
+    { name: 'Linode', url: 'https://status.linode.com', category: 'Cloud & CDN' },
+    { name: 'Vultr', url: 'https://status.vultr.com', category: 'Cloud & CDN' },
+    // Monitoring & Observability
+    { name: 'Datadog', url: 'https://status.datadoghq.com', category: 'Monitoring & Observability' },
+    { name: 'PagerDuty', url: 'https://status.pagerduty.com', category: 'Monitoring & Observability' },
+    { name: 'New Relic', url: 'https://status.newrelic.com', category: 'Monitoring & Observability' },
+    { name: 'Sentry', url: 'https://status.sentry.io', category: 'Monitoring & Observability' },
+    { name: 'Statuspage', url: 'https://metastatuspage.com', category: 'Monitoring & Observability' },
+    // Communication
+    { name: 'Slack', url: 'https://status.slack.com', category: 'Communication' },
+    { name: 'Discord', url: 'https://discordstatus.com', category: 'Communication' },
+    { name: 'Zoom', url: 'https://status.zoom.us', category: 'Communication' },
+    { name: 'Twilio', url: 'https://status.twilio.com', category: 'Communication' },
+    { name: 'Loom', url: 'https://www.loomstatus.com', category: 'Communication' },
+    // Productivity
+    { name: 'Notion', url: 'https://status.notion.so', category: 'Productivity' },
+    { name: 'Figma', url: 'https://status.figma.com', category: 'Productivity' },
+    { name: 'Miro', url: 'https://status.miro.com', category: 'Productivity' },
+    { name: 'Airtable', url: 'https://status.airtable.com', category: 'Productivity' },
+    { name: 'Asana', url: 'https://trust.asana.com', category: 'Productivity' },
+    { name: 'Monday.com', url: 'https://status.monday.com', category: 'Productivity' },
+    { name: 'ClickUp', url: 'https://clickup.statuspage.io', category: 'Productivity' },
+    { name: 'Coda', url: 'https://status.coda.io', category: 'Productivity' },
+    { name: '1Password', url: 'https://status.1password.com', category: 'Productivity' },
+    // E-commerce & Payments
+    { name: 'Stripe', url: 'https://status.stripe.com', category: 'E-commerce & Payments' },
+    { name: 'Shopify', url: 'https://status.shopify.com', category: 'E-commerce & Payments' },
+    { name: 'Square', url: 'https://issquareup.com', category: 'E-commerce & Payments' },
+    { name: 'Braintree', url: 'https://status.braintreepayments.com', category: 'E-commerce & Payments' },
+    // Email & Marketing
+    { name: 'SendGrid', url: 'https://status.sendgrid.com', category: 'Email & Marketing' },
+    { name: 'Mailchimp', url: 'https://status.mailchimp.com', category: 'Email & Marketing' },
+    { name: 'Postmark', url: 'https://status.postmarkapp.com', category: 'Email & Marketing' },
+    { name: 'Mailgun', url: 'https://status.mailgun.com', category: 'Email & Marketing' },
+    // Data & Analytics
+    { name: 'Segment', url: 'https://status.segment.com', category: 'Data & Analytics' },
+    { name: 'Amplitude', url: 'https://status.amplitude.com', category: 'Data & Analytics' },
+    { name: 'Mixpanel', url: 'https://status.mixpanel.com', category: 'Data & Analytics' },
+    { name: 'Snowflake', url: 'https://status.snowflake.com', category: 'Data & Analytics' },
+    // Databases
+    { name: 'MongoDB Atlas', url: 'https://status.cloud.mongodb.com', category: 'Databases' },
+    { name: 'PlanetScale', url: 'https://www.planetscalestatus.com', category: 'Databases' },
+    { name: 'Supabase', url: 'https://status.supabase.com', category: 'Databases' },
+    { name: 'Redis Cloud', url: 'https://status.redis.io', category: 'Databases' },
+    { name: 'Neon', url: 'https://neonstatus.com', category: 'Databases' },
+    // Customer Support & CRM
+    { name: 'Zendesk', url: 'https://status.zendesk.com', category: 'Customer Support & CRM' },
+    { name: 'Intercom', url: 'https://www.intercomstatus.com', category: 'Customer Support & CRM' },
+    { name: 'HubSpot', url: 'https://status.hubspot.com', category: 'Customer Support & CRM' },
+    // Security & Auth
+    { name: 'Okta', url: 'https://status.okta.com', category: 'Security & Auth' },
+    { name: 'Auth0', url: 'https://status.auth0.com', category: 'Security & Auth' },
+    { name: 'HashiCorp', url: 'https://status.hashicorp.com', category: 'Security & Auth' },
+    // Media & Entertainment
+    { name: 'Spotify', url: 'https://status.spotify.dev', category: 'Media & Entertainment' },
+    { name: 'Vimeo', url: 'https://status.vimeo.com', category: 'Media & Entertainment' }
+  ];
+
+  var selectedUrls = new Set();
+
+  function escapeHtml(str) {
+    var div = document.createElement('div');
+    div.appendChild(document.createTextNode(str));
+    return div.innerHTML;
+  }
+
+  function escapeAttr(str) {
+    return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
+  function downloadTSV(filename, content) {
+    var blob = new Blob([content], { type: 'text/tab-separated-values;charset=utf-8' });
+    var a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(a.href);
+  }
+
+  function renderSources(filter) {
+    var listEl = document.getElementById('source-list');
+    var countEl = document.getElementById('source-count');
+    var selectAllEl = document.getElementById('source-select-all');
+    var exportBtn = document.getElementById('source-export');
+    if (!listEl) return;
+
+    var lowerFilter = (filter || '').toLowerCase();
+    var filtered = STATUS_SOURCES.filter(function (s) {
+      return !lowerFilter || s.name.toLowerCase().indexOf(lowerFilter) !== -1 || s.url.toLowerCase().indexOf(lowerFilter) !== -1;
+    });
+
+    // Group by category preserving order
+    var groups = [];
+    var groupMap = {};
+    filtered.forEach(function (s) {
+      if (!groupMap[s.category]) {
+        groupMap[s.category] = [];
+        groups.push({ category: s.category, items: groupMap[s.category] });
+      }
+      groupMap[s.category].push(s);
+    });
+
+    if (filtered.length === 0) {
+      listEl.innerHTML = '<div class="source-empty">No services match your search.</div>';
+    } else {
+      var html = '';
+      groups.forEach(function (g) {
+        html += '<div class="source-category">' + escapeHtml(g.category) + '</div>';
+        g.items.forEach(function (s) {
+          var checked = selectedUrls.has(s.url) ? ' checked' : '';
+          var selectedClass = selectedUrls.has(s.url) ? ' selected' : '';
+          html += '<div class="source-item' + selectedClass + '" role="listitem" data-url="' + escapeAttr(s.url) + '">'
+            + '<span class="source-check" role="checkbox" aria-checked="' + (selectedUrls.has(s.url) ? 'true' : 'false') + '" aria-label="Select ' + escapeAttr(s.name) + '"><svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="#fff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M2 5l2.5 2.5L8 3"/></svg></span>'
+            + '<span class="source-item-name">' + escapeHtml(s.name) + '</span>'
+            + '<span class="source-item-url">' + escapeHtml(s.url) + '</span>'
+            + '<button class="source-copy-btn" data-copy="' + escapeAttr(s.url) + '" aria-label="Copy URL">Copy</button>'
+            + '</div>';
+        });
+      });
+      listEl.innerHTML = html;
+    }
+
+    // Count
+    if (countEl) {
+      countEl.textContent = filtered.length + ' of ' + STATUS_SOURCES.length + ' services';
+    }
+
+    // Select-all state
+    var selectAllLabel = document.getElementById('source-select-all-label');
+    if (selectAllEl && selectAllLabel) {
+      var visibleSelected = filtered.filter(function (s) { return selectedUrls.has(s.url); }).length;
+      selectAllLabel.classList.remove('checked', 'indeterminate');
+      if (visibleSelected === 0) {
+        selectAllEl.checked = false;
+      } else if (visibleSelected === filtered.length) {
+        selectAllEl.checked = true;
+        selectAllLabel.classList.add('checked');
+      } else {
+        selectAllEl.checked = false;
+        selectAllLabel.classList.add('indeterminate');
+      }
+    }
+
+    // Export button
+    if (exportBtn) {
+      exportBtn.disabled = selectedUrls.size === 0;
+      if (selectedUrls.size > 0) {
+        exportBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v8m0 0L5 7m3 3 3-3M3 12h10"/></svg> Export ' + selectedUrls.size + ' as TSV';
+      } else {
+        exportBtn.innerHTML = '<svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v8m0 0L5 7m3 3 3-3M3 12h10"/></svg> Export TSV';
+      }
+    }
+  }
+
+  // Event handlers for source directory
+  var searchInput = document.getElementById('source-search');
+  var sourceList = document.getElementById('source-list');
+  var selectAllCheckbox = document.getElementById('source-select-all');
+  var exportButton = document.getElementById('source-export');
+
+  if (searchInput) {
+    var debounceTimer;
+    searchInput.addEventListener('input', function () {
+      clearTimeout(debounceTimer);
+      var val = searchInput.value;
+      debounceTimer = setTimeout(function () {
+        renderSources(val);
+      }, 120);
+    });
+
+    searchInput.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        searchInput.value = '';
+        searchInput.blur();
+        renderSources('');
+      }
+    });
+  }
+
+  if (sourceList) {
+    sourceList.addEventListener('click', function (e) {
+      // Copy button
+      var copyBtn = e.target.closest('.source-copy-btn');
+      if (copyBtn) {
+        var url = copyBtn.getAttribute('data-copy');
+        navigator.clipboard.writeText(url).then(function () {
+          copyBtn.textContent = 'Copied!';
+          setTimeout(function () { copyBtn.textContent = 'Copy'; }, 1500);
+        }).catch(function () {
+          copyBtn.textContent = 'Failed';
+          setTimeout(function () { copyBtn.textContent = 'Copy'; }, 1500);
+        });
+        return;
+      }
+
+      // Row toggle
+      var item = e.target.closest('.source-item');
+      if (item) {
+        var url = item.getAttribute('data-url');
+        if (selectedUrls.has(url)) {
+          selectedUrls.delete(url);
+        } else {
+          selectedUrls.add(url);
+        }
+        renderSources(searchInput ? searchInput.value : '');
+      }
+    });
+  }
+
+  if (selectAllCheckbox) {
+    selectAllCheckbox.addEventListener('change', function () {
+      var lowerFilter = (searchInput ? searchInput.value : '').toLowerCase();
+      var visible = STATUS_SOURCES.filter(function (s) {
+        return !lowerFilter || s.name.toLowerCase().indexOf(lowerFilter) !== -1 || s.url.toLowerCase().indexOf(lowerFilter) !== -1;
+      });
+      if (selectAllCheckbox.checked) {
+        visible.forEach(function (s) { selectedUrls.add(s.url); });
+      } else {
+        visible.forEach(function (s) { selectedUrls.delete(s.url); });
+      }
+      renderSources(searchInput ? searchInput.value : '');
+    });
+  }
+
+  if (exportButton) {
+    exportButton.addEventListener('click', function () {
+      if (selectedUrls.size === 0) return;
+      var lines = [];
+      STATUS_SOURCES.forEach(function (s) {
+        if (selectedUrls.has(s.url)) {
+          lines.push(s.name + '\t' + s.url);
+        }
+      });
+      downloadTSV('status-pages.tsv', lines.join('\n'));
+    });
+  }
+
+  // Initial render
+  renderSources('');
+
   // --- IntersectionObserver for active nav link ---
   const sections = document.querySelectorAll('section[id]');
   const navLinks = document.querySelectorAll('.nav-links a[href^="#"]');

--- a/docs/style.css
+++ b/docs/style.css
@@ -616,63 +616,288 @@ section {
 .doc-layout {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 40px;
-  align-items: start;
+  gap: 32px;
+  align-items: center;
 }
 
 .doc-screenshot {
-  max-width: 280px;
+  max-width: 240px;
 }
 
 .doc-desc {
-  font-size: 0.875rem;
+  font-size: 0.9375rem;
   color: var(--text-secondary);
-  margin-bottom: 16px;
   line-height: 1.6;
 }
 
-.doc-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.875rem;
+.doc-desc-hint {
+  margin-top: 12px;
+  font-size: 0.8125rem;
+  color: var(--text-tertiary);
 }
 
-.doc-table th,
-.doc-table td {
-  text-align: left;
-  padding: 10px 16px;
+/* --- Source Directory --- */
+.source-directory {
+  margin-top: 32px;
+}
+
+.source-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.source-search {
+  flex: 1;
+  padding: 8px 12px;
+  background: var(--glass-bg);
+  border: 0.5px solid var(--glass-border);
+  border-radius: var(--radius-small);
+  color: var(--text-primary);
+  font-size: 0.8125rem;
+  font-family: inherit;
+  outline: none;
+  transition: border-color var(--timing-hover) ease-out;
+}
+
+.source-search::placeholder {
+  color: var(--text-tertiary);
+}
+
+.source-search:focus {
+  border-color: var(--accent);
+}
+
+.source-count {
+  font-size: 0.75rem;
+  color: var(--text-tertiary);
+  white-space: nowrap;
+}
+
+.source-list {
+  max-height: 460px;
+  overflow-y: auto;
+  background: var(--glass-bg);
+  border: 0.5px solid var(--glass-border);
+  border-radius: var(--radius-card);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+}
+
+.source-list::-webkit-scrollbar {
+  width: 6px;
+}
+
+.source-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.source-list::-webkit-scrollbar-thumb {
+  background: var(--glass-border);
+  border-radius: 3px;
+}
+
+.source-category {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  padding: 8px 16px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-tertiary);
+  background: #1a1a1e;
   border-bottom: 0.5px solid var(--glass-border);
 }
 
-.doc-table th {
-  font-weight: 600;
-  color: var(--text-secondary);
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+@media (prefers-color-scheme: light) {
+  .source-category {
+    background: #e8e8ec;
+  }
 }
 
-.doc-table td {
+.source-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  font-size: 0.8125rem;
+  border-bottom: 0.5px solid var(--glass-border);
+  transition: background var(--timing-hover) ease-out;
+}
+
+.source-item:last-child {
+  border-bottom: none;
+}
+
+.source-item:hover {
+  background: var(--glass-hover);
+}
+
+.source-item.selected {
+  background: rgba(0, 122, 255, 0.06);
+}
+
+.source-check {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  border: 1.5px solid var(--glass-border);
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--timing-hover) ease-out,
+              border-color var(--timing-hover) ease-out;
+}
+
+.source-check svg {
+  display: none;
+}
+
+.source-item.selected .source-check {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.source-item.selected .source-check svg {
+  display: block;
+}
+
+.source-item-name {
+  font-weight: 500;
+  white-space: nowrap;
   color: var(--text-primary);
 }
 
-.doc-table code {
+.source-item-url {
+  flex: 1;
+  min-width: 0;
   font-family: 'SF Mono', SFMono-Regular, ui-monospace, Menlo, Monaco, monospace;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.source-copy-btn {
+  flex-shrink: 0;
+  background: var(--glass-bg);
+  border: 0.5px solid var(--glass-border);
+  border-radius: var(--radius-small);
+  color: var(--text-secondary);
+  font-size: 0.6875rem;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: color var(--timing-hover) ease-out,
+              background var(--timing-hover) ease-out;
+}
+
+.source-copy-btn:hover {
+  color: var(--text-primary);
+  background: var(--glass-hover);
+}
+
+.source-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 12px;
+}
+
+.source-select-all {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-size: 0.8125rem;
-  background: var(--code-bg);
-  padding: 2px 6px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.source-select-all input[type="checkbox"] {
+  display: none;
+}
+
+.source-select-check {
+  width: 16px;
+  height: 16px;
   border-radius: 4px;
+  border: 1.5px solid var(--glass-border);
+  background: transparent;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background var(--timing-hover) ease-out,
+              border-color var(--timing-hover) ease-out;
+}
+
+.source-select-check .check-icon,
+.source-select-check .minus-icon {
+  display: none;
+}
+
+.source-select-all.checked .source-select-check {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.source-select-all.checked .source-select-check .check-icon {
+  display: block;
+}
+
+.source-select-all.indeterminate .source-select-check {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+
+.source-select-all.indeterminate .source-select-check .minus-icon {
+  display: block;
+}
+
+.source-export-btn[disabled] {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.source-empty {
+  padding: 32px 16px;
+  text-align: center;
+  font-size: 0.875rem;
+  color: var(--text-tertiary);
+}
+
+@media (max-width: 640px) {
+  .source-item {
+    flex-wrap: wrap;
+  }
+
+  .source-item-url {
+    width: 100%;
+    padding-left: 26px;
+  }
+
+  .source-copy-btn {
+    margin-left: auto;
+  }
 }
 
 @media (max-width: 768px) {
   .doc-layout {
     grid-template-columns: 1fr;
-    gap: 24px;
+    text-align: center;
   }
 
   .doc-screenshot {
-    max-width: 300px;
+    max-width: 220px;
     margin: 0 auto;
+  }
+
+  .doc-content {
+    text-align: left;
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace the static 8-row table in the docs site with a JS-rendered, searchable, category-grouped directory of 70 Atlassian Statuspage-powered services
- Users can multi-select services, export as TSV, and import directly into StatusBar
- Custom-styled checkboxes, sticky category headers, debounced search, and responsive layout

## Test plan
- [ ] Open docs site and verify the searchable directory renders with all 70 entries
- [ ] Search filters in real-time; Escape clears search
- [ ] Select services and verify Export TSV downloads correct `name\turl` format
- [ ] Import the exported TSV into StatusBar and verify it parses correctly
- [ ] Verify light/dark mode, mobile responsiveness, and sticky headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)