### PR TITLE
ci: update release runner to macos-26

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   build-and-release:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Updates release workflow runner from `macos-15` to `macos-26` to match the app's target SDK
- Fixes release build failure caused by macOS 26-only APIs (`.glassEffect`) not available on macOS 15

## Test plan
- [x] CI pipeline passes on `macos-26`
- [ ] Re-run release workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)