### PR TITLE
feat: improve DX and Claude Code setup

### DIFF
--- a/.claude/hooks.json
+++ b/.claude/hooks.json
@@ -1,0 +1,13 @@
+{
+  "hooks": [
+    {
+      "matcher": "Bash(make build*)",
+      "hooks": [
+        {
+          "type": "afterToolResult",
+          "command": "make lint 2>&1 | tail -5"
+        }
+      ]
+    }
+  ]
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,22 @@
 {
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(make build:*)",
+      "Bash(make test:*)",
+      "Bash(make lint:*)",
+      "Bash(make format:*)",
+      "Bash(make format-check:*)",
+      "Bash(make check:*)",
+      "Bash(make clean:*)",
+      "Bash(make setup:*)",
+      "Bash(make dev:*)",
+      "Bash(./build.sh:*)",
+      "Bash(./test.sh:*)",
+      "Bash(swiftlint:*)",
+      "Bash(swift-format:*)"
+    ]
   }
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.swift]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,14 @@
 # Contributing
 
+## Getting Started
+
+```bash
+make setup         # Install tools (SwiftLint, swift-format, Lefthook) and git hooks
+make dev           # Build and open the app
+```
+
+This runs `brew bundle` to install dependencies from the `Brewfile` and `lefthook install` to set up pre-commit and pre-push hooks.
+
 ## Build from Source
 
 ```bash
@@ -28,14 +37,20 @@ make format        # Auto-format code with swift-format
 make format-check  # Check formatting without modifying files
 make check         # Run lint + format check + tests (CI target)
 make clean         # Remove build artifacts
+make setup         # Install tools and git hooks
+make dev           # Build and open the app
 make install       # Build and copy .app to /Applications
 ```
 
 ### Prerequisites
 
 - macOS 14+ with Xcode Command Line Tools
-- [SwiftLint](https://github.com/realm/SwiftLint): `brew install swiftlint`
-- [swift-format](https://github.com/swiftlang/swift-format): `brew install swift-format`
+- [Homebrew](https://brew.sh)
+
+All other dependencies are installed via `make setup` (which runs `brew bundle`):
+- [SwiftLint](https://github.com/realm/SwiftLint)
+- [swift-format](https://github.com/swiftlang/swift-format)
+- [Lefthook](https://github.com/evilmartians/lefthook) — git hooks manager
 
 ### Running Tests
 
@@ -50,6 +65,10 @@ Test files live in `Tests/` alongside JSON fixtures in `Tests/Fixtures/`. Test d
 ### Code Quality
 
 The project uses SwiftLint for style enforcement and swift-format for consistent formatting. CI runs `make check` on every push to `main` and every pull request.
+
+Lefthook hooks are installed automatically via `make setup` and enforce:
+- **pre-commit**: auto-formats code and runs lint
+- **pre-push**: runs the full `make check` suite
 
 Before submitting a PR:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+
+<!-- Brief description of the changes -->
+
+## Checklist
+
+- [ ] `make check` passes (lint + format + tests)
+- [ ] Screenshot/recording attached if UI change
+- [ ] New source files: checked if `test.sh` needs to exclude them

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Cache Homebrew
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/Homebrew
+            /opt/homebrew/Cellar/swiftlint
+            /opt/homebrew/Cellar/swift-format
+          key: brew-${{ runner.os }}-${{ hashFiles('Brewfile') }}
+          restore-keys: brew-${{ runner.os }}-
+
       - name: Install tools
-        run: brew install swiftlint swift-format
+        run: brew bundle
 
       - name: Lint (SwiftLint)
         run: make lint

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 *.swp
 *.swo
 *~
+.claude/settings.local.json

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,3 @@
+brew "swiftlint"
+brew "swift-format"
+brew "lefthook"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# StatusBar — Claude Code Context
+
+## Build & Test
+
+```bash
+make setup          # One-time: install tools + git hooks (brew bundle && lefthook install)
+make build          # Dev build (arm64, fast)
+make test           # Run unit tests
+make lint           # SwiftLint --strict on Sources/ and Tests/
+make format         # Auto-format with swift-format
+make format-check   # Check formatting (fails if changes needed)
+make check          # Lint + format check + tests (CI target)
+make dev            # Build and open the app
+make clean          # Remove build artifacts
+```
+
+## Architecture
+
+- **Pure `swiftc` build** — no SPM or Xcode project. All `.swift` files in `Sources/` compile as a single compilation unit via `build.sh`.
+- **Test harness** — `test.sh` compiles `Tests/` + most of `Sources/` into an XCTest bundle. It **excludes** `StatusBarApp.swift` (has `@main`) and `HotkeyManager.swift` (requires Carbon framework).
+- **Settings** — `@AppStorage` for user preferences. `HistoryStore` uses file-based JSON in `~/Library/Application Support/StatusBar/`.
+- **macOS 26** — targets macOS 26 with Liquid Glass (`.glassEffect`, `.buttonStyle(.glass)`, `.chromeBackground()`).
+
+## Key Gotchas
+
+- **SourceKit false positives** — SourceKit reports "Cannot find X in scope" for cross-file references because there's no SPM package. Ignore these; only `make build` matters.
+- **test.sh exclusions** — when adding new source files that depend on Carbon or system frameworks, add them to the exclusion list in `test.sh`.
+- **SwiftUI Color types** — `Color.secondary` works as a `Color`, but `.tertiary`/`.quaternary` are `ShapeStyle` only. Use `.gray` in `-> Color` return types.
+- **AppDelegate access** — `@NSApplicationDelegateAdaptor` wraps the delegate in a proxy. `NSApp.delegate as? AppDelegate` returns nil. Use `ScriptBridge.service` for AppleScript commands.
+- **No HotkeyManager in views** — don't reference `HotkeyManager` from views compiled in the test target. Use inline constants instead.
+
+## Coding Conventions
+
+- 4-space indentation, 140-char line length (see `.swift-format`)
+- No SPM dependencies — everything is compiled directly with `swiftc`
+- `@AppStorage` for simple settings, file-based JSON for complex data (history)
+- SwiftLint + swift-format enforced in CI and pre-commit hooks

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release test lint format format-check check clean install help
+.PHONY: build release test lint format format-check check clean install setup dev help
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -26,6 +26,14 @@ check: lint format-check test ## Run lint + format check + tests (CI target)
 
 clean: ## Remove build artifacts
 	@rm -rf build/ .build-tests/
+
+setup: ## Install tools and git hooks (one-time bootstrap)
+	@brew bundle
+	@lefthook install
+	@echo "Setup complete."
+
+dev: build ## Build and open the app
+	@open ./build/StatusBar.app
 
 install: build ## Build and copy .app to /Applications
 	@cp -R build/StatusBar.app /Applications/

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,14 @@
+pre-commit:
+  commands:
+    format:
+      glob: "*.swift"
+      run: make format
+      stage_fixed: true
+    lint:
+      glob: "*.swift"
+      run: make lint
+
+pre-push:
+  commands:
+    check:
+      run: make check


### PR DESCRIPTION
## Summary

Closes #16

- **One-command bootstrap**: `make setup` installs tools (SwiftLint, swift-format, Lefthook) and git hooks
- **Shared Claude Code context**: `CLAUDE.md` with build commands, architecture overview, and key gotchas
- **Local quality gates**: Lefthook pre-commit (format + lint) and pre-push (full check) hooks
- **CI optimization**: Homebrew caching via `actions/cache` keyed on `Brewfile`
- **DX conveniences**: `make dev` (build + open), `.editorconfig`, PR template with checklist
- **Shared permissions**: `.claude/settings.json` allows build/test/lint commands for all contributors

## Test plan

- [x] `make check` passes (lint + format-check + 158 tests)
- [x] All JSON files validate (hooks.json, settings.json, settings.local.json)
- [x] `make setup` installs tools and Lefthook hooks
- [x] `make dev` builds and opens the app
- [x] `git commit` on a dirty Swift file triggers pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)