### PR TITLE
feat: distribute via Homebrew cask (#18)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,15 @@ jobs:
         run: |
           lipo -info build/StatusBar.app/Contents/MacOS/StatusBar
 
+      - name: Create stable-named archive for Homebrew
+        run: cp "build/StatusBar-${{ steps.version.outputs.version }}.zip" build/StatusBar-universal.zip
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: ${{ steps.version.outputs.version }}
           generate_release_notes: true
-          files: build/StatusBar-${{ steps.version.outputs.version }}.zip
+          files: |
+            build/StatusBar-${{ steps.version.outputs.version }}.zip
+            build/StatusBar-universal.zip

--- a/README.md
+++ b/README.md
@@ -31,11 +31,19 @@
 
 ## 📦 Install
 
-Grab the latest universal binary from the [Releases page](https://github.com/alexnodeland/StatusBar/releases/latest):
+### Homebrew (recommended)
 
-1. Download `StatusBar-vX.Y.Z-universal.zip`
+```bash
+brew tap alexnodeland/tap
+brew install --cask statusbar
+```
+
+### Manual download
+
+1. Download `StatusBar-vX.Y.Z.zip` from the [Releases page](https://github.com/alexnodeland/StatusBar/releases/latest)
 2. Extract and drag `StatusBar.app` to `/Applications`
-3. On first launch, right-click → **Open** to bypass Gatekeeper (ad-hoc signed, not notarized)
+3. Remove quarantine: `xattr -cr /Applications/StatusBar.app`
+4. Launch normally
 
 Runs natively on both Apple Silicon and Intel Macs.
 

--- a/StatusBar.entitlements
+++ b/StatusBar.entitlements
@@ -5,7 +5,5 @@
 <dict>
     <key>com.apple.security.app-sandbox</key>
     <false/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
 </dict>
 </plist>

--- a/build.sh
+++ b/build.sh
@@ -154,7 +154,7 @@ if [ -n "${CODESIGN_IDENTITY:-}" ]; then
         --entitlements StatusBar.entitlements --timestamp "${APP_BUNDLE}"
 else
     # Ad-hoc signing (local development)
-    codesign --force --sign - --entitlements StatusBar.entitlements "${APP_BUNDLE}"
+    codesign --force --sign - --options runtime --entitlements StatusBar.entitlements "${APP_BUNDLE}"
 fi
 
 echo "✅ Built successfully: ${APP_BUNDLE}"


### PR DESCRIPTION
## Summary

- Remove `allow-unsigned-executable-memory` entitlement (pure AOT Swift, no JIT needed)
- Enable hardened runtime (`--options runtime`) for ad-hoc signed builds
- Add stable-named `StatusBar-universal.zip` release artifact for Homebrew cask URL
- Update README with Homebrew as primary install method, manual download as fallback with `xattr -cr`
- Created [`alexnodeland/homebrew-tap`](https://github.com/alexnodeland/homebrew-tap) with cask formula

## Test plan
- [x] `make build` succeeds
- [x] `codesign -d --entitlements - build/StatusBar.app` shows no `allow-unsigned-executable-memory`
- [x] `codesign -dv build/StatusBar.app` shows `runtime` in flags
- [x] App launches, fetches status pages, hotkey works
- [ ] After tagging a release: `brew tap alexnodeland/tap && brew install --cask statusbar` installs the app