### PR TITLE
feat: add Gatus support with automatic provider detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">StatusBar</h1>
 
 <p align="center">
-  A single-file SwiftUI menu bar app that monitors multiple status pages simultaneously. Supports <a href="https://www.atlassian.com/software/statuspage">Atlassian Statuspage</a>, <a href="https://incident.io">incident.io</a>, and <a href="https://instatus.com">Instatus</a>-powered pages with automatic provider detection.
+  A single-file SwiftUI menu bar app that monitors multiple status pages simultaneously. Supports <a href="https://www.atlassian.com/software/statuspage">Atlassian Statuspage</a>, <a href="https://incident.io">incident.io</a>, <a href="https://instatus.com">Instatus</a>, and self-hosted <a href="https://gatus.io">Gatus</a> pages with automatic provider detection.
 </p>
 
 <p align="center">
@@ -70,10 +70,11 @@ Open **Settings** and click **+** to add more. The app auto-detects the provider
 | Notion | Atlassian Statuspage | `https://status.notion.so` |
 | Zed | Instatus | `https://status.zed.dev` |
 | Deno | Instatus | `https://denostatus.com` |
+| Gatus demo | Gatus | `https://status.twin.sh` |
 
 </details>
 
-> **Note:** Incident history detail varies by provider. Atlassian Statuspage sources include full incident timelines. incident.io and Instatus sources may have limited or unavailable incident details due to provider API restrictions.
+> **Note:** Incident history detail varies by provider. Atlassian Statuspage sources include full incident timelines. incident.io and Instatus sources may have limited or unavailable incident details due to provider API restrictions. Gatus sources report per-endpoint health (each endpoint appears as a component) but have no incident history.
 
 Sources are persisted as JSON via `@AppStorage` and survive restarts. Use **Settings → Data** to export/import a full configuration (settings, sources, webhooks) or sources only.
 

--- a/Sources/Models.swift
+++ b/Sources/Models.swift
@@ -337,6 +337,91 @@ struct InstatusComponent: Codable {
     let children: [InstatusComponent]
 }
 
+// MARK: - Gatus API Models
+
+struct GatusEndpointStatus: Codable {
+    let name: String
+    let group: String?
+    let key: String?
+    let results: [GatusResult]
+
+    enum CodingKeys: String, CodingKey {
+        case name, group, key, results
+    }
+
+    init(name: String, group: String?, key: String?, results: [GatusResult]) {
+        self.name = name
+        self.group = group
+        self.key = key
+        self.results = results
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        group = try container.decodeIfPresent(String.self, forKey: .group)
+        key = try container.decodeIfPresent(String.self, forKey: .key)
+        results = try container.decodeIfPresent([GatusResult].self, forKey: .results) ?? []
+    }
+
+    // Gatus appends results chronologically; the last entry is the most recent check.
+    var latestResult: GatusResult? { results.last }
+
+    var displayName: String {
+        guard let group, !group.isEmpty else { return name }
+        return "\(group) / \(name)"
+    }
+}
+
+struct GatusResult: Codable {
+    let success: Bool
+    let timestamp: String?
+}
+
+extension SPSummary {
+    static func fromGatus(_ endpoints: [GatusEndpointStatus], baseURL: String) -> SPSummary {
+        let components = endpoints.enumerated().map { index, endpoint -> SPComponent in
+            let status: String
+            if let latest = endpoint.latestResult {
+                status = latest.success ? "operational" : "major_outage"
+            } else {
+                status = "unknown"
+            }
+            return SPComponent(
+                id: endpoint.key ?? endpoint.name,
+                name: endpoint.displayName,
+                status: status,
+                description: nil,
+                position: index,
+                groupId: nil
+            )
+        }
+
+        let checked = endpoints.filter { $0.latestResult != nil }
+        let downCount = checked.filter { $0.latestResult?.success == false }.count
+
+        let indicator: String
+        let description: String
+        if checked.isEmpty || downCount == 0 {
+            indicator = "none"
+            description = "All systems operational"
+        } else if downCount == checked.count {
+            indicator = "critical"
+            description = "All \(checked.count) endpoints down"
+        } else {
+            indicator = "major"
+            description = "\(downCount) of \(checked.count) endpoints down"
+        }
+
+        return SPSummary(
+            page: SPPage(id: baseURL, name: baseURL, url: baseURL, updatedAt: "", timeZone: nil),
+            status: SPStatus(indicator: indicator, description: description),
+            components: components,
+            incidents: []
+        )
+    }
+}
+
 // MARK: - GitHub Release Model
 
 struct GitHubRelease: Codable {
@@ -414,6 +499,7 @@ enum StatusProvider: Equatable {
     case incidentIOCompat  // incident.io pages serving Atlassian-compatible API (no update details)
     case incidentIO  // pure incident.io fallback via /proxy/widget
     case instatus
+    case gatus  // self-hosted Gatus instances via /api/v1/endpoints/statuses
 }
 
 // MARK: - Status History

--- a/Sources/SourceDetailView.swift
+++ b/Sources/SourceDetailView.swift
@@ -201,7 +201,7 @@ struct SourceDetailView: View {
 
     private var providerLimitationNotice: String? {
         switch state.provider {
-        case .instatus:
+        case .instatus, .gatus:
             return "Incident history is not available for this status page provider"
         case .incidentIO, .incidentIOCompat:
             return "Incident details are not available for this status page provider"

--- a/Sources/StatusService+Providers.swift
+++ b/Sources/StatusService+Providers.swift
@@ -1,0 +1,236 @@
+// StatusService+Providers.swift
+// Provider detection and per-provider fetch + mapping (Atlassian, incident.io, Instatus, Gatus).
+
+import Foundation
+
+extension StatusService {
+
+    // MARK: - Provider Detection
+
+    func detectProvider(baseURL: String) async -> StatusProvider {
+        guard let url = URL(string: "\(baseURL)/api/v2/summary.json") else {
+            return .incidentIO
+        }
+        do {
+            let (data, response) = try await withRetry {
+                try await self.session.data(from: url)
+            }
+            if let http = response as? HTTPURLResponse, http.statusCode == 200 {
+                // Try Atlassian-format first (has status.indicator object)
+                if let summary = try? JSONDecoder().decode(SPSummary.self, from: data) {
+                    // Atlassian pages include time_zone; incident.io compat pages don't
+                    return summary.page.timeZone != nil ? .atlassian : .incidentIOCompat
+                }
+                // Try Instatus (has page.status as a plain string like "UP")
+                if (try? JSONDecoder().decode(InstatusSummary.self, from: data)) != nil {
+                    return .instatus
+                }
+            }
+        } catch {}
+        if await isGatus(baseURL: baseURL) {
+            return .gatus
+        }
+        return .incidentIO
+    }
+
+    private func isGatus(baseURL: String) async -> Bool {
+        guard let url = URL(string: "\(baseURL)/api/v1/endpoints/statuses?page=1&pageSize=1") else {
+            return false
+        }
+        guard let (data, response) = try? await session.data(from: url),
+            let http = response as? HTTPURLResponse, http.statusCode == 200
+        else { return false }
+        return (try? JSONDecoder().decode([GatusEndpointStatus].self, from: data)) != nil
+    }
+
+    // MARK: - Atlassian Fetch
+
+    func fetchSummary(baseURL: String) async throws -> SPSummary {
+        try await withRetry {
+            let url = URL(string: "\(baseURL)/api/v2/summary.json")!
+            let (data, _) = try await self.session.data(from: url)
+            return try JSONDecoder().decode(SPSummary.self, from: data)
+        }
+    }
+
+    func fetchIncidents(baseURL: String) async throws -> [SPIncident] {
+        try await withRetry {
+            let url = URL(string: "\(baseURL)/api/v2/incidents.json")!
+            let (data, _) = try await self.session.data(from: url)
+            return try JSONDecoder().decode(SPIncidentsResponse.self, from: data).incidents
+        }
+    }
+
+    // MARK: - incident.io Fetch + Mapping
+
+    func fetchIncidentIO(baseURL: String) async throws -> (SPSummary, [SPIncident]) {
+        let (data, _) = try await withRetry {
+            let url = URL(string: "\(baseURL)/proxy/widget")!
+            return try await self.session.data(from: url)
+        }
+        let widget = try JSONDecoder().decode(IIOWidgetResponse.self, from: data)
+
+        let allIncidents =
+            (widget.ongoingIncidents ?? [])
+            + (widget.inProgressMaintenances ?? [])
+
+        let mappedIncidents = allIncidents.map { inc -> SPIncident in
+            let id = inc.id ?? UUID().uuidString
+            let name = inc.name ?? "Unknown incident"
+            let status = inc.status ?? "investigating"
+            let impact = deriveImpact(from: status)
+            let created = inc.createdAt ?? ""
+            let updated = inc.updatedAt ?? ""
+
+            var updates: [SPIncidentUpdate] = []
+            if let msg = inc.lastUpdateMessage, !msg.isEmpty {
+                updates.append(
+                    SPIncidentUpdate(
+                        id: "\(id)-update",
+                        status: status,
+                        body: msg,
+                        createdAt: updated,
+                        updatedAt: updated
+                    ))
+            }
+
+            return SPIncident(
+                id: id,
+                name: name,
+                status: status,
+                impact: impact,
+                createdAt: created,
+                updatedAt: updated,
+                shortlink: nil,
+                incidentUpdates: updates
+            )
+        }
+
+        let indicator = deriveIndicator(from: allIncidents)
+        let description = deriveDescription(from: indicator, incidentCount: allIncidents.count)
+
+        let summary = SPSummary(
+            page: SPPage(id: baseURL, name: baseURL, url: baseURL, updatedAt: "", timeZone: nil),
+            status: SPStatus(indicator: indicator, description: description),
+            components: [],
+            incidents: mappedIncidents
+        )
+
+        return (summary, mappedIncidents)
+    }
+
+    private func deriveImpact(from status: String) -> String {
+        let map = ["investigating": "major", "identified": "major", "monitoring": "minor", "resolved": "none", "postmortem": "none"]
+        return map[status.lowercased(), default: "minor"]
+    }
+
+    private func deriveIndicator(from incidents: [IIOIncident]) -> String {
+        if incidents.isEmpty { return "none" }
+        for inc in incidents {
+            let s = (inc.status ?? "").lowercased()
+            if s == "investigating" || s == "identified" { return "major" }
+        }
+        return "minor"
+    }
+
+    private func deriveDescription(from indicator: String, incidentCount: Int) -> String {
+        if indicator == "none" { return "All systems operational" }
+        let suffix = incidentCount == 1 ? "" : "s"
+        if indicator == "minor" || indicator == "major" {
+            return "\(incidentCount) active incident\(suffix)"
+        }
+        return "Status unknown"
+    }
+
+    // MARK: - Instatus Fetch + Mapping
+
+    func fetchInstatus(baseURL: String) async throws -> SPSummary {
+        let (summaryData, _) = try await withRetry {
+            let summaryURL = URL(string: "\(baseURL)/api/v2/summary.json")!
+            return try await self.session.data(from: summaryURL)
+        }
+        let instatus = try JSONDecoder().decode(InstatusSummary.self, from: summaryData)
+
+        var components: [SPComponent] = []
+        if let compURL = URL(string: "\(baseURL)/api/v2/components.json") {
+            if let (compData, compResp) = try? await session.data(from: compURL),
+                let compHTTP = compResp as? HTTPURLResponse, compHTTP.statusCode == 200,
+                let parsed = try? JSONDecoder().decode(InstatusComponentsResponse.self, from: compData)
+            {
+                components = flattenInstatusComponents(parsed.components)
+            }
+        }
+
+        let indicator = mapInstatusPageStatus(instatus.page.status)
+        let description = mapInstatusDescription(instatus.page.status)
+
+        return SPSummary(
+            page: SPPage(id: baseURL, name: instatus.page.name, url: instatus.page.url, updatedAt: "", timeZone: nil),
+            status: SPStatus(indicator: indicator, description: description),
+            components: components,
+            incidents: []
+        )
+    }
+
+    private func flattenInstatusComponents(_ components: [InstatusComponent], position: inout Int) -> [SPComponent] {
+        var result: [SPComponent] = []
+        for comp in components {
+            let mapped = SPComponent(
+                id: comp.id,
+                name: comp.name,
+                status: mapInstatusComponentStatus(comp.status),
+                description: comp.description,
+                position: position,
+                groupId: nil
+            )
+            position += 1
+            result.append(mapped)
+            if !comp.children.isEmpty {
+                result += flattenInstatusComponents(comp.children, position: &position)
+            }
+        }
+        return result
+    }
+
+    private func flattenInstatusComponents(_ components: [InstatusComponent]) -> [SPComponent] {
+        var pos = 0
+        return flattenInstatusComponents(components, position: &pos)
+    }
+
+    private func mapInstatusPageStatus(_ status: String) -> String {
+        ["UP": "none", "HASISSUES": "minor", "UNDERMAINTENANCE": "minor"][status, default: "major"]
+    }
+
+    private func mapInstatusDescription(_ status: String) -> String {
+        let map = ["UP": "All systems operational", "HASISSUES": "Experiencing issues", "UNDERMAINTENANCE": "Under maintenance"]
+        return map[status, default: "Experiencing issues"]
+    }
+
+    private func mapInstatusComponentStatus(_ status: String) -> String {
+        let map = [
+            "OPERATIONAL": "operational",
+            "DEGRADEDPERFORMANCE": "degraded_performance",
+            "PARTIALOUTAGE": "partial_outage",
+            "MAJOROUTAGE": "major_outage",
+            "UNDERMAINTENANCE": "degraded_performance",
+        ]
+        return map[status, default: status.lowercased()]
+    }
+
+    // MARK: - Gatus Fetch + Mapping
+
+    func fetchGatus(baseURL: String) async throws -> SPSummary {
+        let pageSize = 100
+        var endpoints: [GatusEndpointStatus] = []
+        for page in 1...5 {
+            let (data, _) = try await withRetry {
+                let url = URL(string: "\(baseURL)/api/v1/endpoints/statuses?page=\(page)&pageSize=\(pageSize)")!
+                return try await self.session.data(from: url)
+            }
+            let batch = try JSONDecoder().decode([GatusEndpointStatus].self, from: data)
+            endpoints += batch
+            if batch.count < pageSize { break }
+        }
+        return SPSummary.fromGatus(endpoints, baseURL: baseURL)
+    }
+}

--- a/Sources/StatusService+Providers.swift
+++ b/Sources/StatusService+Providers.swift
@@ -231,6 +231,10 @@ extension StatusService {
             endpoints += batch
             if batch.count < pageSize { break }
         }
-        return SPSummary.fromGatus(endpoints, baseURL: baseURL)
+        // Older Gatus versions ignore pagination params and return everything on
+        // every page — dedupe by key so those instances don't produce duplicates.
+        var seen = Set<String>()
+        let unique = endpoints.filter { seen.insert($0.key ?? $0.displayName).inserted }
+        return SPSummary.fromGatus(unique, baseURL: baseURL)
     }
 }

--- a/Sources/StatusService.swift
+++ b/Sources/StatusService.swift
@@ -21,7 +21,7 @@ final class StatusService: ObservableObject {
     let historyStore = HistoryStore()
     @AppStorage("statusHistory") private var storedHistory: String = "{}"
 
-    private let session: URLSession = {
+    let session: URLSession = {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 15
         config.timeoutIntervalForResource = 30
@@ -144,6 +144,9 @@ final class StatusService: ObservableObject {
             case .instatus:
                 summary = try await fetchInstatus(baseURL: source.baseURL)
                 incidents = []
+            case .gatus:
+                summary = try await fetchGatus(baseURL: source.baseURL)
+                incidents = []
             }
 
             let newIndicator = summary.status.indicator
@@ -234,205 +237,8 @@ final class StatusService: ObservableObject {
         )
     }
 
-    private func fetchSummary(baseURL: String) async throws -> SPSummary {
-        try await withRetry {
-            let url = URL(string: "\(baseURL)/api/v2/summary.json")!
-            let (data, _) = try await self.session.data(from: url)
-            return try JSONDecoder().decode(SPSummary.self, from: data)
-        }
-    }
-
-    private func fetchIncidents(baseURL: String) async throws -> [SPIncident] {
-        try await withRetry {
-            let url = URL(string: "\(baseURL)/api/v2/incidents.json")!
-            let (data, _) = try await self.session.data(from: url)
-            return try JSONDecoder().decode(SPIncidentsResponse.self, from: data).incidents
-        }
-    }
-
     private func severityFor(_ indicator: String) -> Int {
         ["none": 0, "minor": 1, "major": 2, "critical": 3][indicator, default: -1]
-    }
-
-    // MARK: - Provider Detection
-
-    private func detectProvider(baseURL: String) async -> StatusProvider {
-        guard let url = URL(string: "\(baseURL)/api/v2/summary.json") else {
-            return .incidentIO
-        }
-        do {
-            let (data, response) = try await withRetry {
-                try await self.session.data(from: url)
-            }
-            if let http = response as? HTTPURLResponse, http.statusCode == 200 {
-                // Try Atlassian-format first (has status.indicator object)
-                if let summary = try? JSONDecoder().decode(SPSummary.self, from: data) {
-                    // Atlassian pages include time_zone; incident.io compat pages don't
-                    return summary.page.timeZone != nil ? .atlassian : .incidentIOCompat
-                }
-                // Try Instatus (has page.status as a plain string like "UP")
-                if (try? JSONDecoder().decode(InstatusSummary.self, from: data)) != nil {
-                    return .instatus
-                }
-            }
-        } catch {}
-        return .incidentIO
-    }
-
-    // MARK: - incident.io Fetch + Mapping
-
-    private func fetchIncidentIO(baseURL: String) async throws -> (SPSummary, [SPIncident]) {
-        let (data, _) = try await withRetry {
-            let url = URL(string: "\(baseURL)/proxy/widget")!
-            return try await self.session.data(from: url)
-        }
-        let widget = try JSONDecoder().decode(IIOWidgetResponse.self, from: data)
-
-        let allIncidents =
-            (widget.ongoingIncidents ?? [])
-            + (widget.inProgressMaintenances ?? [])
-
-        let mappedIncidents = allIncidents.map { inc -> SPIncident in
-            let id = inc.id ?? UUID().uuidString
-            let name = inc.name ?? "Unknown incident"
-            let status = inc.status ?? "investigating"
-            let impact = deriveImpact(from: status)
-            let created = inc.createdAt ?? ""
-            let updated = inc.updatedAt ?? ""
-
-            var updates: [SPIncidentUpdate] = []
-            if let msg = inc.lastUpdateMessage, !msg.isEmpty {
-                updates.append(
-                    SPIncidentUpdate(
-                        id: "\(id)-update",
-                        status: status,
-                        body: msg,
-                        createdAt: updated,
-                        updatedAt: updated
-                    ))
-            }
-
-            return SPIncident(
-                id: id,
-                name: name,
-                status: status,
-                impact: impact,
-                createdAt: created,
-                updatedAt: updated,
-                shortlink: nil,
-                incidentUpdates: updates
-            )
-        }
-
-        let indicator = deriveIndicator(from: allIncidents)
-        let description = deriveDescription(from: indicator, incidentCount: allIncidents.count)
-
-        let summary = SPSummary(
-            page: SPPage(id: baseURL, name: baseURL, url: baseURL, updatedAt: "", timeZone: nil),
-            status: SPStatus(indicator: indicator, description: description),
-            components: [],
-            incidents: mappedIncidents
-        )
-
-        return (summary, mappedIncidents)
-    }
-
-    private func deriveImpact(from status: String) -> String {
-        let map = ["investigating": "major", "identified": "major", "monitoring": "minor", "resolved": "none", "postmortem": "none"]
-        return map[status.lowercased(), default: "minor"]
-    }
-
-    private func deriveIndicator(from incidents: [IIOIncident]) -> String {
-        if incidents.isEmpty { return "none" }
-        for inc in incidents {
-            let s = (inc.status ?? "").lowercased()
-            if s == "investigating" || s == "identified" { return "major" }
-        }
-        return "minor"
-    }
-
-    private func deriveDescription(from indicator: String, incidentCount: Int) -> String {
-        if indicator == "none" { return "All systems operational" }
-        let suffix = incidentCount == 1 ? "" : "s"
-        if indicator == "minor" || indicator == "major" {
-            return "\(incidentCount) active incident\(suffix)"
-        }
-        return "Status unknown"
-    }
-
-    // MARK: - Instatus Fetch + Mapping
-
-    private func fetchInstatus(baseURL: String) async throws -> SPSummary {
-        let (summaryData, _) = try await withRetry {
-            let summaryURL = URL(string: "\(baseURL)/api/v2/summary.json")!
-            return try await self.session.data(from: summaryURL)
-        }
-        let instatus = try JSONDecoder().decode(InstatusSummary.self, from: summaryData)
-
-        var components: [SPComponent] = []
-        if let compURL = URL(string: "\(baseURL)/api/v2/components.json") {
-            if let (compData, compResp) = try? await session.data(from: compURL),
-                let compHTTP = compResp as? HTTPURLResponse, compHTTP.statusCode == 200,
-                let parsed = try? JSONDecoder().decode(InstatusComponentsResponse.self, from: compData)
-            {
-                components = flattenInstatusComponents(parsed.components)
-            }
-        }
-
-        let indicator = mapInstatusPageStatus(instatus.page.status)
-        let description = mapInstatusDescription(instatus.page.status)
-
-        return SPSummary(
-            page: SPPage(id: baseURL, name: instatus.page.name, url: instatus.page.url, updatedAt: "", timeZone: nil),
-            status: SPStatus(indicator: indicator, description: description),
-            components: components,
-            incidents: []
-        )
-    }
-
-    private func flattenInstatusComponents(_ components: [InstatusComponent], position: inout Int) -> [SPComponent] {
-        var result: [SPComponent] = []
-        for comp in components {
-            let mapped = SPComponent(
-                id: comp.id,
-                name: comp.name,
-                status: mapInstatusComponentStatus(comp.status),
-                description: comp.description,
-                position: position,
-                groupId: nil
-            )
-            position += 1
-            result.append(mapped)
-            if !comp.children.isEmpty {
-                result += flattenInstatusComponents(comp.children, position: &position)
-            }
-        }
-        return result
-    }
-
-    private func flattenInstatusComponents(_ components: [InstatusComponent]) -> [SPComponent] {
-        var pos = 0
-        return flattenInstatusComponents(components, position: &pos)
-    }
-
-    private func mapInstatusPageStatus(_ status: String) -> String {
-        ["UP": "none", "HASISSUES": "minor", "UNDERMAINTENANCE": "minor"][status, default: "major"]
-    }
-
-    private func mapInstatusDescription(_ status: String) -> String {
-        let map = ["UP": "All systems operational", "HASISSUES": "Experiencing issues", "UNDERMAINTENANCE": "Under maintenance"]
-        return map[status, default: "Experiencing issues"]
-    }
-
-    private func mapInstatusComponentStatus(_ status: String) -> String {
-        let map = [
-            "OPERATIONAL": "operational",
-            "DEGRADEDPERFORMANCE": "degraded_performance",
-            "PARTIALOUTAGE": "partial_outage",
-            "MAJOROUTAGE": "major_outage",
-            "UNDERMAINTENANCE": "degraded_performance",
-        ]
-        return map[status, default: status.lowercased()]
     }
 
     // MARK: - Source Management

--- a/Tests/Fixtures/gatus_statuses.json
+++ b/Tests/Fixtures/gatus_statuses.json
@@ -1,0 +1,62 @@
+[
+    {
+        "name": "frontend",
+        "group": "core",
+        "key": "core_frontend",
+        "results": [
+            {
+                "status": 200,
+                "hostname": "example.org",
+                "duration": 149819678,
+                "conditionResults": [
+                    { "condition": "[STATUS] == 200", "success": true }
+                ],
+                "success": true,
+                "timestamp": "2026-07-19T10:00:00Z"
+            },
+            {
+                "status": 200,
+                "hostname": "example.org",
+                "duration": 131201233,
+                "conditionResults": [
+                    { "condition": "[STATUS] == 200", "success": true }
+                ],
+                "success": true,
+                "timestamp": "2026-07-19T10:05:00Z"
+            }
+        ]
+    },
+    {
+        "name": "api",
+        "group": "core",
+        "key": "core_api",
+        "results": [
+            {
+                "status": 200,
+                "hostname": "api.example.org",
+                "duration": 93214111,
+                "conditionResults": [
+                    { "condition": "[STATUS] == 200", "success": true }
+                ],
+                "success": true,
+                "timestamp": "2026-07-19T10:00:00Z"
+            },
+            {
+                "status": 500,
+                "hostname": "api.example.org",
+                "duration": 87301998,
+                "conditionResults": [
+                    { "condition": "[STATUS] == 200", "success": false }
+                ],
+                "success": false,
+                "timestamp": "2026-07-19T10:05:00Z"
+            }
+        ]
+    },
+    {
+        "name": "backups",
+        "group": "",
+        "key": "_backups",
+        "results": []
+    }
+]

--- a/Tests/ModelsTests.swift
+++ b/Tests/ModelsTests.swift
@@ -142,6 +142,83 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(apiComp.children[0].children.count, 0)
     }
 
+    // MARK: - Gatus Models
+
+    func testGatusEndpointStatusDecode() {
+        let data = loadFixture("gatus_statuses.json")
+        let endpoints = try! JSONDecoder().decode([GatusEndpointStatus].self, from: data)
+        XCTAssertEqual(endpoints.count, 3)
+        XCTAssertEqual(endpoints[0].name, "frontend")
+        XCTAssertEqual(endpoints[0].group, "core")
+        XCTAssertEqual(endpoints[0].key, "core_frontend")
+        XCTAssertEqual(endpoints[0].results.count, 2)
+        XCTAssertEqual(endpoints[2].results.count, 0)
+    }
+
+    func testGatusEndpointStatusMissingResultsDefaultsToEmpty() {
+        let json = """
+            [{"name":"db","group":"infra","key":"infra_db"}]
+            """.data(using: .utf8)!
+        let endpoints = try! JSONDecoder().decode([GatusEndpointStatus].self, from: json)
+        XCTAssertEqual(endpoints[0].results.count, 0)
+        XCTAssertNil(endpoints[0].latestResult)
+    }
+
+    func testGatusLatestResultIsLast() {
+        let data = loadFixture("gatus_statuses.json")
+        let endpoints = try! JSONDecoder().decode([GatusEndpointStatus].self, from: data)
+        // Gatus appends results chronologically; the last entry is the newest check
+        XCTAssertEqual(endpoints[0].latestResult?.success, true)
+        XCTAssertEqual(endpoints[1].latestResult?.success, false)
+    }
+
+    func testGatusDisplayNameIncludesGroup() {
+        let grouped = GatusEndpointStatus(name: "api", group: "core", key: "core_api", results: [])
+        let ungrouped = GatusEndpointStatus(name: "backups", group: "", key: "_backups", results: [])
+        XCTAssertEqual(grouped.displayName, "core / api")
+        XCTAssertEqual(ungrouped.displayName, "backups")
+    }
+
+    func testGatusSummaryMappingPartialOutage() {
+        let data = loadFixture("gatus_statuses.json")
+        let endpoints = try! JSONDecoder().decode([GatusEndpointStatus].self, from: data)
+        let summary = SPSummary.fromGatus(endpoints, baseURL: "https://status.example.org")
+        XCTAssertEqual(summary.status.indicator, "major")
+        XCTAssertEqual(summary.status.description, "1 of 2 endpoints down")
+        XCTAssertEqual(summary.components.count, 3)
+        XCTAssertEqual(summary.components[0].name, "core / frontend")
+        XCTAssertEqual(summary.components[0].status, "operational")
+        XCTAssertEqual(summary.components[1].status, "major_outage")
+        XCTAssertEqual(summary.components[2].status, "unknown")
+        XCTAssertEqual(summary.incidents.count, 0)
+    }
+
+    func testGatusSummaryMappingAllUp() {
+        let endpoints = [
+            GatusEndpointStatus(name: "a", group: nil, key: "a", results: [GatusResult(success: true, timestamp: nil)]),
+            GatusEndpointStatus(name: "b", group: nil, key: "b", results: [GatusResult(success: true, timestamp: nil)]),
+        ]
+        let summary = SPSummary.fromGatus(endpoints, baseURL: "https://status.example.org")
+        XCTAssertEqual(summary.status.indicator, "none")
+        XCTAssertEqual(summary.status.description, "All systems operational")
+    }
+
+    func testGatusSummaryMappingAllDown() {
+        let endpoints = [
+            GatusEndpointStatus(name: "a", group: nil, key: "a", results: [GatusResult(success: false, timestamp: nil)]),
+            GatusEndpointStatus(name: "b", group: nil, key: "b", results: [GatusResult(success: false, timestamp: nil)]),
+        ]
+        let summary = SPSummary.fromGatus(endpoints, baseURL: "https://status.example.org")
+        XCTAssertEqual(summary.status.indicator, "critical")
+        XCTAssertEqual(summary.status.description, "All 2 endpoints down")
+    }
+
+    func testGatusSummaryMappingEmpty() {
+        let summary = SPSummary.fromGatus([], baseURL: "https://status.example.org")
+        XCTAssertEqual(summary.status.indicator, "none")
+        XCTAssertEqual(summary.components.count, 0)
+    }
+
     // MARK: - GitHub Models
 
     func testGitHubReleaseFullFixture() {

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>StatusBar — Monitor Status Pages from Your Menu Bar</title>
-  <meta name="description" content="A native macOS menu bar app that monitors multiple status pages simultaneously. Supports Atlassian Statuspage, incident.io, and Instatus with automatic provider detection.">
+  <meta name="description" content="A native macOS menu bar app that monitors multiple status pages simultaneously. Supports Atlassian Statuspage, incident.io, Instatus, and self-hosted Gatus with automatic provider detection.">
   <meta property="og:title" content="StatusBar">
-  <meta property="og:description" content="Monitor multiple status pages from your macOS menu bar. Supports Atlassian Statuspage, incident.io, and Instatus.">
+  <meta property="og:description" content="Monitor multiple status pages from your macOS menu bar. Supports Atlassian Statuspage, incident.io, Instatus, and self-hosted Gatus.">
   <meta property="og:image" content="icon.png">
   <meta property="og:type" content="website">
   <meta name="twitter:card" content="summary">
@@ -45,7 +45,7 @@
     <div class="container">
       <img src="icon.png" alt="StatusBar app icon" class="hero-icon" width="128" height="128">
       <h1>StatusBar</h1>
-      <p class="hero-tagline">A native macOS menu bar app that monitors all your status pages in one place. Supports Atlassian Statuspage, incident.io, and Instatus with automatic provider detection. No Dock icon. No Electron. Just a single icon that tells you everything.</p>
+      <p class="hero-tagline">A native macOS menu bar app that monitors all your status pages in one place. Supports Atlassian Statuspage, incident.io, Instatus, and self-hosted Gatus with automatic provider detection. No Dock icon. No Electron. Just a single icon that tells you everything.</p>
       <div class="hero-ctas">
         <a href="https://github.com/alexnodeland/StatusBar/releases/latest" class="btn btn-primary">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 2v8m0 0L5 7m3 3 3-3M3 12h10"/></svg>
@@ -441,7 +441,7 @@ open ./build/StatusBar.app</code></pre>
             <img src="screenshots/settings.png" alt="Settings view showing source management and preferences" class="screenshot">
           </div>
           <div class="doc-content">
-            <p class="doc-desc">Open Settings and click <strong>+</strong> to add any status page by name and URL. The app auto-detects the provider &mdash; <a href="https://www.atlassian.com/software/statuspage">Atlassian Statuspage</a>, <a href="https://incident.io">incident.io</a>, or <a href="https://instatus.com">Instatus</a>. You can also import a JSON file to add many at once.</p>
+            <p class="doc-desc">Open Settings and click <strong>+</strong> to add any status page by name and URL. The app auto-detects the provider &mdash; <a href="https://www.atlassian.com/software/statuspage">Atlassian Statuspage</a>, <a href="https://incident.io">incident.io</a>, <a href="https://instatus.com">Instatus</a>, or <a href="https://gatus.io">Gatus</a>. You can also import a JSON file to add many at once.</p>
             <p class="doc-desc doc-desc-hint">Select services below, export as JSON, then import the file in StatusBar via Settings&nbsp;&rarr;&nbsp;Data&nbsp;&rarr;&nbsp;Import Sources.</p>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Adds [Gatus](https://gatus.io) as a fourth supported status page provider, alongside Atlassian Statuspage, incident.io, and Instatus.

- **Detection**: after the existing `/api/v2/summary.json` probes fail, StatusBar probes `/api/v1/endpoints/statuses` — if it returns a valid Gatus payload, the source is treated as a Gatus instance (falling back to incident.io as before).
- **Mapping**: each Gatus endpoint becomes a component named `group / name`, colored by its latest check result (`operational` / `major_outage`, `unknown` when no checks have run yet). The aggregate indicator is `none` when everything is up, `critical` when every checked endpoint is down, and `major` otherwise, with a "N of M endpoints down" description.
- **Pagination**: fetches up to 5 pages × 100 endpoints per refresh.
- **UI**: Gatus sources show the same "incident history not available" notice as Instatus, since Gatus has no incident API.
- **Refactor**: provider detection and per-provider fetch/mapping moved from `StatusService.swift` into a new `StatusService+Providers.swift` extension to stay within SwiftLint file/type length limits.
- **Tests**: new `gatus_statuses.json` fixture plus decode and mapping tests (partial outage, all up, all down, empty, missing results).
- **Docs**: README and docs site updated; example table now includes the public Gatus demo instance (`https://status.twin.sh`).

## Test plan

- `make check` — lint, format check, and all 182 unit tests pass
- `make build` — app builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015b2b1TQZjDQnSsHCUpkFxC