### PR TITLE
fix: repo-wide sweep — notification bugs, release signing, min-OS mismatch, hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Cache Homebrew
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/Library/Caches/Homebrew

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,10 +22,10 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/checkout@v7
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Determine version
         id: version
@@ -74,7 +74,7 @@ jobs:
         run: cp "build/StatusBar-${{ steps.version.outputs.version }}.zip" build/StatusBar-universal.zip
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.version.outputs.version }}
           name: ${{ steps.version.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Import signing certificate
-        if: env.APPLE_CERTIFICATE != ''
+        if: ${{ secrets.APPLE_CERTIFICATE != '' }}
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -47,7 +47,7 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
 
       - name: Setup notarization profile
-        if: env.NOTARIZE_APPLE_ID != ''
+        if: ${{ secrets.NOTARIZE_APPLE_ID != '' }}
         env:
           NOTARIZE_APPLE_ID: ${{ secrets.NOTARIZE_APPLE_ID }}
           NOTARIZE_PASSWORD: ${{ secrets.NOTARIZE_PASSWORD }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ make lint           # SwiftLint --strict on Sources/ and Tests/
 make format         # Auto-format with swift-format
 make format-check   # Check formatting (fails if changes needed)
 make check          # Lint + format check + tests (CI target)
+make release        # Release build (universal binary + ZIP)
+make install        # Build and copy to /Applications
 make dev            # Build and open the app
 make clean          # Remove build artifacts
 ```
@@ -17,7 +19,7 @@ make clean          # Remove build artifacts
 ## Architecture
 
 - **Pure `swiftc` build** — no SPM or Xcode project. All `.swift` files in `Sources/` compile as a single compilation unit via `build.sh`.
-- **Test harness** — `test.sh` compiles `Tests/` + most of `Sources/` into an XCTest bundle. It **excludes** `StatusBarApp.swift` (has `@main`) and `HotkeyManager.swift` (requires Carbon framework).
+- **Test harness** — `test.sh` compiles `Tests/` + most of `Sources/` into an XCTest bundle. It **excludes** `StatusBarApp.swift` (has `@main`), `HotkeyManager.swift` (requires Carbon framework), and `AppleScriptBridge.swift` (scripting classes only referenced from `StatusBarApp.swift`).
 - **Settings** — `@AppStorage` for user preferences. `HistoryStore` uses file-based JSON in `~/Library/Application Support/StatusBar/`.
 - **macOS 26** — targets macOS 26 with Liquid Glass (`.glassEffect`, `.buttonStyle(.glass)`, `.chromeBackground()`).
 

--- a/Info.plist
+++ b/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundleIconFile</key>
     <string>StatusBar</string>
     <key>LSMinimumSystemVersion</key>
-    <string>14.0</string>
+    <string>26.0</string>
     <key>LSUIElement</key>
     <true/>
     <key>NSAppTransportSecurity</key>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/macOS-14%2B-blue" alt="macOS 14+">
+  <img src="https://img.shields.io/badge/macOS-26%2B-blue" alt="macOS 26+">
   <img src="https://img.shields.io/badge/Swift-5.9%2B-orange" alt="Swift 5.9+">
   <a href="https://github.com/alexnodeland/StatusBar/releases/latest"><img src="https://img.shields.io/github/v/release/alexnodeland/StatusBar" alt="GitHub Release"></a>
   <a href="https://alexnodeland.github.io/StatusBar/"><img src="https://img.shields.io/badge/docs-website-blue" alt="Docs"></a>
@@ -141,7 +141,7 @@ StatusBar exposes a full scripting dictionary for AppleScript and JXA (JavaScrip
 ```applescript
 tell application "StatusBar"
     get name of every source           -- list source names
-    get status of source "GitHub"      -- "none" / "minor" / "major" / "critical"
+    get status of source "GitHub"      -- "none" / "minor" / "major" / "critical" / "unknown"
     get worst status                   -- aggregate worst status
     get issue count                    -- number of sources with issues
 
@@ -164,6 +164,7 @@ osascript -e 'tell application "StatusBar" to refresh'
 
 | Property | Type | Description |
 |----------|------|-------------|
+| `id` | text | Unique identifier (UUID) |
 | `name` | text | Display name |
 | `url` | text | Base URL of the status page |
 | `status` | text | Current indicator (`none`, `minor`, `major`, `critical`, `unknown`) |
@@ -176,10 +177,11 @@ osascript -e 'tell application "StatusBar" to refresh'
 ## 🛠 Development
 
 ```bash
-brew install swiftlint swift-format   # One-time setup
+make setup                            # One-time: brew bundle + git hooks
 make build                            # Dev build
 make test                             # Run tests
 make check                            # Full CI check (lint + format + test)
+make release                          # Release build (universal binary + ZIP)
 ```
 
 See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for the full development guide.

--- a/Sources/Constants.swift
+++ b/Sources/Constants.swift
@@ -28,7 +28,6 @@ let kServiceCatalog: [CatalogEntry] = [
     CatalogEntry(name: "Cloudflare", url: "https://www.cloudflarestatus.com", category: "Infrastructure"),
     CatalogEntry(name: "Anthropic", url: "https://status.anthropic.com", category: "AI & ML"),
     CatalogEntry(name: "OpenAI", url: "https://status.openai.com", category: "AI & ML"),
-    CatalogEntry(name: "AWS", url: "https://health.aws.amazon.com", category: "Cloud"),
     CatalogEntry(name: "Datadog", url: "https://status.datadoghq.com", category: "Observability"),
     CatalogEntry(name: "PagerDuty", url: "https://status.pagerduty.com", category: "Incident Management"),
     CatalogEntry(name: "Vercel", url: "https://www.vercel-status.com", category: "Developer Tools"),

--- a/Sources/Helpers.swift
+++ b/Sources/Helpers.swift
@@ -146,6 +146,32 @@ func validateSourceURL(_ rawURL: String) -> URLValidationResult {
 
 // MARK: - Network Retry
 
+enum FetchError: LocalizedError, Equatable {
+    case invalidURL
+    case httpStatus(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL: return "Invalid URL"
+        case .httpStatus(let code): return "Server returned status \(code)"
+        }
+    }
+
+    /// Client errors (4xx) and unparseable URLs won't succeed on retry.
+    var isRetryable: Bool {
+        switch self {
+        case .invalidURL: return false
+        case .httpStatus(let code): return code >= 500
+        }
+    }
+}
+
+func isRetryableError(_ error: Error) -> Bool {
+    if error is DecodingError { return false }
+    if let fetchError = error as? FetchError { return fetchError.isRetryable }
+    return true
+}
+
 func withRetry<T>(
     maxAttempts: Int = kMaxRetries,
     baseDelay: TimeInterval = kRetryBaseDelay,
@@ -157,6 +183,7 @@ func withRetry<T>(
         do {
             return try await operation()
         } catch {
+            guard isRetryableError(error) else { throw error }
             lastError = error
             if attempt < maxAttempts - 1 {
                 let delay = min(baseDelay * pow(2.0, Double(attempt)), maxDelay)

--- a/Sources/Models.swift
+++ b/Sources/Models.swift
@@ -59,7 +59,7 @@ extension WebhookEvent {
         self.init(
             source: source.name, title: title, body: body,
             severity: summary.status.indicator, event: event, url: source.baseURL,
-            timestamp: ISO8601DateFormatter().string(from: Date()),
+            timestamp: isoFormatterNoFrac.string(from: Date()),
             components: summary.components.filter { $0.status != "operational" }.map(\.name)
         )
     }
@@ -146,7 +146,7 @@ struct StatusBarConfig: Codable, Equatable {
 
     init(settings: ConfigSettings, sources: [StatusSource], webhooks: [WebhookConfig]) {
         self.version = Self.currentVersion
-        self.exportedAt = ISO8601DateFormatter().string(from: Date())
+        self.exportedAt = isoFormatterNoFrac.string(from: Date())
         self.settings = settings
         self.sources = sources
         self.webhooks = webhooks
@@ -376,50 +376,6 @@ struct GatusEndpointStatus: Codable {
 struct GatusResult: Codable {
     let success: Bool
     let timestamp: String?
-}
-
-extension SPSummary {
-    static func fromGatus(_ endpoints: [GatusEndpointStatus], baseURL: String) -> SPSummary {
-        let components = endpoints.enumerated().map { index, endpoint -> SPComponent in
-            let status: String
-            if let latest = endpoint.latestResult {
-                status = latest.success ? "operational" : "major_outage"
-            } else {
-                status = "unknown"
-            }
-            return SPComponent(
-                id: endpoint.key ?? endpoint.name,
-                name: endpoint.displayName,
-                status: status,
-                description: nil,
-                position: index,
-                groupId: nil
-            )
-        }
-
-        let checked = endpoints.filter { $0.latestResult != nil }
-        let downCount = checked.filter { $0.latestResult?.success == false }.count
-
-        let indicator: String
-        let description: String
-        if checked.isEmpty || downCount == 0 {
-            indicator = "none"
-            description = "All systems operational"
-        } else if downCount == checked.count {
-            indicator = "critical"
-            description = "All \(checked.count) endpoints down"
-        } else {
-            indicator = "major"
-            description = "\(downCount) of \(checked.count) endpoints down"
-        }
-
-        return SPSummary(
-            page: SPPage(id: baseURL, name: baseURL, url: baseURL, updatedAt: "", timeZone: nil),
-            status: SPStatus(indicator: indicator, description: description),
-            components: components,
-            incidents: []
-        )
-    }
 }
 
 // MARK: - GitHub Release Model

--- a/Sources/ProviderMappings.swift
+++ b/Sources/ProviderMappings.swift
@@ -1,0 +1,188 @@
+// ProviderMappings.swift
+// Pure mappings from provider-specific API models into the common SPSummary model.
+
+import Foundation
+
+// MARK: - incident.io Mapping
+
+extension SPSummary {
+    static func fromIncidentIOWidget(_ widget: IIOWidgetResponse, baseURL: String) -> (summary: SPSummary, incidents: [SPIncident]) {
+        let allIncidents =
+            (widget.ongoingIncidents ?? [])
+            + (widget.inProgressMaintenances ?? [])
+
+        let mappedIncidents = allIncidents.map { inc -> SPIncident in
+            let id = inc.id ?? UUID().uuidString
+            let name = inc.name ?? "Unknown incident"
+            let status = inc.status ?? "investigating"
+            let impact = deriveIncidentIOImpact(from: status)
+            let created = inc.createdAt ?? ""
+            let updated = inc.updatedAt ?? ""
+
+            var updates: [SPIncidentUpdate] = []
+            if let msg = inc.lastUpdateMessage, !msg.isEmpty {
+                updates.append(
+                    SPIncidentUpdate(
+                        id: "\(id)-update",
+                        status: status,
+                        body: msg,
+                        createdAt: updated,
+                        updatedAt: updated
+                    ))
+            }
+
+            return SPIncident(
+                id: id,
+                name: name,
+                status: status,
+                impact: impact,
+                createdAt: created,
+                updatedAt: updated,
+                shortlink: nil,
+                incidentUpdates: updates
+            )
+        }
+
+        let indicator = deriveIncidentIOIndicator(from: allIncidents)
+        let description = deriveIncidentIODescription(from: indicator, incidentCount: allIncidents.count)
+
+        let summary = SPSummary(
+            page: SPPage(id: baseURL, name: baseURL, url: baseURL, updatedAt: "", timeZone: nil),
+            status: SPStatus(indicator: indicator, description: description),
+            components: [],
+            incidents: mappedIncidents
+        )
+
+        return (summary, mappedIncidents)
+    }
+}
+
+func deriveIncidentIOImpact(from status: String) -> String {
+    let map = ["investigating": "major", "identified": "major", "monitoring": "minor", "resolved": "none", "postmortem": "none"]
+    return map[status.lowercased(), default: "minor"]
+}
+
+func deriveIncidentIOIndicator(from incidents: [IIOIncident]) -> String {
+    if incidents.isEmpty { return "none" }
+    for inc in incidents {
+        let s = (inc.status ?? "").lowercased()
+        if s == "investigating" || s == "identified" { return "major" }
+    }
+    return "minor"
+}
+
+func deriveIncidentIODescription(from indicator: String, incidentCount: Int) -> String {
+    if indicator == "none" { return "All systems operational" }
+    let suffix = incidentCount == 1 ? "" : "s"
+    if indicator == "minor" || indicator == "major" {
+        return "\(incidentCount) active incident\(suffix)"
+    }
+    return "Status unknown"
+}
+
+// MARK: - Instatus Mapping
+
+extension SPSummary {
+    static func fromInstatus(_ instatus: InstatusSummary, components: [InstatusComponent], baseURL: String) -> SPSummary {
+        SPSummary(
+            page: SPPage(id: baseURL, name: instatus.page.name, url: instatus.page.url, updatedAt: "", timeZone: nil),
+            status: SPStatus(
+                indicator: mapInstatusPageStatus(instatus.page.status),
+                description: mapInstatusDescription(instatus.page.status)
+            ),
+            components: flattenInstatusComponents(components),
+            incidents: []
+        )
+    }
+}
+
+func flattenInstatusComponents(_ components: [InstatusComponent]) -> [SPComponent] {
+    var pos = 0
+    return flattenInstatusComponents(components, position: &pos)
+}
+
+private func flattenInstatusComponents(_ components: [InstatusComponent], position: inout Int) -> [SPComponent] {
+    var result: [SPComponent] = []
+    for comp in components {
+        let mapped = SPComponent(
+            id: comp.id,
+            name: comp.name,
+            status: mapInstatusComponentStatus(comp.status),
+            description: comp.description,
+            position: position,
+            groupId: nil
+        )
+        position += 1
+        result.append(mapped)
+        if !comp.children.isEmpty {
+            result += flattenInstatusComponents(comp.children, position: &position)
+        }
+    }
+    return result
+}
+
+func mapInstatusPageStatus(_ status: String) -> String {
+    ["UP": "none", "HASISSUES": "minor", "UNDERMAINTENANCE": "minor"][status, default: "major"]
+}
+
+func mapInstatusDescription(_ status: String) -> String {
+    let map = ["UP": "All systems operational", "HASISSUES": "Experiencing issues", "UNDERMAINTENANCE": "Under maintenance"]
+    return map[status, default: "Experiencing issues"]
+}
+
+func mapInstatusComponentStatus(_ status: String) -> String {
+    let map = [
+        "OPERATIONAL": "operational",
+        "DEGRADEDPERFORMANCE": "degraded_performance",
+        "PARTIALOUTAGE": "partial_outage",
+        "MAJOROUTAGE": "major_outage",
+        "UNDERMAINTENANCE": "degraded_performance",
+    ]
+    return map[status, default: status.lowercased()]
+}
+
+// MARK: - Gatus Mapping
+
+extension SPSummary {
+    static func fromGatus(_ endpoints: [GatusEndpointStatus], baseURL: String) -> SPSummary {
+        let components = endpoints.enumerated().map { index, endpoint -> SPComponent in
+            let status: String
+            if let latest = endpoint.latestResult {
+                status = latest.success ? "operational" : "major_outage"
+            } else {
+                status = "unknown"
+            }
+            return SPComponent(
+                id: endpoint.key ?? endpoint.name,
+                name: endpoint.displayName,
+                status: status,
+                description: nil,
+                position: index,
+                groupId: nil
+            )
+        }
+
+        let checked = endpoints.filter { $0.latestResult != nil }
+        let downCount = checked.filter { $0.latestResult?.success == false }.count
+
+        let indicator: String
+        let description: String
+        if checked.isEmpty || downCount == 0 {
+            indicator = "none"
+            description = "All systems operational"
+        } else if downCount == checked.count {
+            indicator = "critical"
+            description = "All \(checked.count) endpoints down"
+        } else {
+            indicator = "major"
+            description = "\(downCount) of \(checked.count) endpoints down"
+        }
+
+        return SPSummary(
+            page: SPPage(id: baseURL, name: baseURL, url: baseURL, updatedAt: "", timeZone: nil),
+            status: SPStatus(indicator: indicator, description: description),
+            components: components,
+            incidents: []
+        )
+    }
+}

--- a/Sources/SourceDetailView.swift
+++ b/Sources/SourceDetailView.swift
@@ -203,9 +203,11 @@ struct SourceDetailView: View {
         switch state.provider {
         case .instatus, .gatus:
             return "Incident history is not available for this status page provider"
-        case .incidentIO, .incidentIOCompat:
+        case .incidentIO:
             return "Incident details are not available for this status page provider"
         default:
+            // .incidentIOCompat serves the Atlassian incidents API, so real
+            // incident details are shown — no limitation to disclose.
             return nil
         }
     }
@@ -460,13 +462,7 @@ struct IncidentCard: View {
     }
 
     private var impactColor: Color {
-        switch incident.impact {
-        case "none": return .green
-        case "minor": return .yellow
-        case "major": return .orange
-        case "critical": return .red
-        default: return .secondary
-        }
+        colorForIndicator(incident.impact)
     }
 
     private var statusBadge: String {

--- a/Sources/StatusBarApp.swift
+++ b/Sources/StatusBarApp.swift
@@ -2,7 +2,7 @@
 // A macOS menu bar app that monitors multiple Atlassian Statuspage-powered status pages.
 // Features native glass UI, status change notifications, and optimized polling.
 //
-// Requirements: macOS 14+ (Sonoma), Swift 5.9+
+// Requirements: macOS 26+ (Liquid Glass APIs)
 //
 // Build & Run:
 //   ./build.sh
@@ -102,6 +102,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             name: NSWindow.didBecomeKeyNotification,
             object: nil
         )
+    }
+
+    @MainActor func applicationWillTerminate(_ notification: Notification) {
+        // History writes are debounced by 5s — flush so the last checkpoints
+        // aren't lost on quit.
+        service?.historyStore.flushToDisk()
     }
 
     @objc private func windowDidBecomeKey(_ notification: Notification) {

--- a/Sources/StatusService+Providers.swift
+++ b/Sources/StatusService+Providers.swift
@@ -1,9 +1,23 @@
 // StatusService+Providers.swift
-// Provider detection and per-provider fetch + mapping (Atlassian, incident.io, Instatus, Gatus).
+// Provider detection and per-provider network fetches. Pure response→SPSummary
+// mapping lives in ProviderMappings.swift.
 
 import Foundation
 
 extension StatusService {
+
+    // MARK: - Shared Fetch
+
+    /// Fetches a URL and returns its body, throwing typed errors for bad URLs
+    /// and non-2xx responses so `withRetry` can skip retries on terminal failures.
+    private func fetchData(_ urlString: String) async throws -> Data {
+        guard let url = URL(string: urlString) else { throw FetchError.invalidURL }
+        let (data, response) = try await session.data(from: url)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            throw FetchError.httpStatus(http.statusCode)
+        }
+        return data
+    }
 
     // MARK: - Provider Detection
 
@@ -34,198 +48,64 @@ extension StatusService {
     }
 
     private func isGatus(baseURL: String) async -> Bool {
-        guard let url = URL(string: "\(baseURL)/api/v1/endpoints/statuses?page=1&pageSize=1") else {
+        guard let data = try? await fetchData("\(baseURL)/api/v1/endpoints/statuses?page=1&pageSize=1") else {
             return false
         }
-        guard let (data, response) = try? await session.data(from: url),
-            let http = response as? HTTPURLResponse, http.statusCode == 200
-        else { return false }
         return (try? JSONDecoder().decode([GatusEndpointStatus].self, from: data)) != nil
     }
 
     // MARK: - Atlassian Fetch
 
     func fetchSummary(baseURL: String) async throws -> SPSummary {
-        try await withRetry {
-            let url = URL(string: "\(baseURL)/api/v2/summary.json")!
-            let (data, _) = try await self.session.data(from: url)
-            return try JSONDecoder().decode(SPSummary.self, from: data)
+        let data = try await withRetry {
+            try await self.fetchData("\(baseURL)/api/v2/summary.json")
         }
+        return try JSONDecoder().decode(SPSummary.self, from: data)
     }
 
     func fetchIncidents(baseURL: String) async throws -> [SPIncident] {
-        try await withRetry {
-            let url = URL(string: "\(baseURL)/api/v2/incidents.json")!
-            let (data, _) = try await self.session.data(from: url)
-            return try JSONDecoder().decode(SPIncidentsResponse.self, from: data).incidents
+        let data = try await withRetry {
+            try await self.fetchData("\(baseURL)/api/v2/incidents.json")
         }
+        return try JSONDecoder().decode(SPIncidentsResponse.self, from: data).incidents
     }
 
-    // MARK: - incident.io Fetch + Mapping
+    // MARK: - incident.io Fetch
 
     func fetchIncidentIO(baseURL: String) async throws -> (SPSummary, [SPIncident]) {
-        let (data, _) = try await withRetry {
-            let url = URL(string: "\(baseURL)/proxy/widget")!
-            return try await self.session.data(from: url)
+        let data = try await withRetry {
+            try await self.fetchData("\(baseURL)/proxy/widget")
         }
         let widget = try JSONDecoder().decode(IIOWidgetResponse.self, from: data)
-
-        let allIncidents =
-            (widget.ongoingIncidents ?? [])
-            + (widget.inProgressMaintenances ?? [])
-
-        let mappedIncidents = allIncidents.map { inc -> SPIncident in
-            let id = inc.id ?? UUID().uuidString
-            let name = inc.name ?? "Unknown incident"
-            let status = inc.status ?? "investigating"
-            let impact = deriveImpact(from: status)
-            let created = inc.createdAt ?? ""
-            let updated = inc.updatedAt ?? ""
-
-            var updates: [SPIncidentUpdate] = []
-            if let msg = inc.lastUpdateMessage, !msg.isEmpty {
-                updates.append(
-                    SPIncidentUpdate(
-                        id: "\(id)-update",
-                        status: status,
-                        body: msg,
-                        createdAt: updated,
-                        updatedAt: updated
-                    ))
-            }
-
-            return SPIncident(
-                id: id,
-                name: name,
-                status: status,
-                impact: impact,
-                createdAt: created,
-                updatedAt: updated,
-                shortlink: nil,
-                incidentUpdates: updates
-            )
-        }
-
-        let indicator = deriveIndicator(from: allIncidents)
-        let description = deriveDescription(from: indicator, incidentCount: allIncidents.count)
-
-        let summary = SPSummary(
-            page: SPPage(id: baseURL, name: baseURL, url: baseURL, updatedAt: "", timeZone: nil),
-            status: SPStatus(indicator: indicator, description: description),
-            components: [],
-            incidents: mappedIncidents
-        )
-
-        return (summary, mappedIncidents)
+        return SPSummary.fromIncidentIOWidget(widget, baseURL: baseURL)
     }
 
-    private func deriveImpact(from status: String) -> String {
-        let map = ["investigating": "major", "identified": "major", "monitoring": "minor", "resolved": "none", "postmortem": "none"]
-        return map[status.lowercased(), default: "minor"]
-    }
-
-    private func deriveIndicator(from incidents: [IIOIncident]) -> String {
-        if incidents.isEmpty { return "none" }
-        for inc in incidents {
-            let s = (inc.status ?? "").lowercased()
-            if s == "investigating" || s == "identified" { return "major" }
-        }
-        return "minor"
-    }
-
-    private func deriveDescription(from indicator: String, incidentCount: Int) -> String {
-        if indicator == "none" { return "All systems operational" }
-        let suffix = incidentCount == 1 ? "" : "s"
-        if indicator == "minor" || indicator == "major" {
-            return "\(incidentCount) active incident\(suffix)"
-        }
-        return "Status unknown"
-    }
-
-    // MARK: - Instatus Fetch + Mapping
+    // MARK: - Instatus Fetch
 
     func fetchInstatus(baseURL: String) async throws -> SPSummary {
-        let (summaryData, _) = try await withRetry {
-            let summaryURL = URL(string: "\(baseURL)/api/v2/summary.json")!
-            return try await self.session.data(from: summaryURL)
+        let summaryData = try await withRetry {
+            try await self.fetchData("\(baseURL)/api/v2/summary.json")
         }
         let instatus = try JSONDecoder().decode(InstatusSummary.self, from: summaryData)
 
-        var components: [SPComponent] = []
-        if let compURL = URL(string: "\(baseURL)/api/v2/components.json") {
-            if let (compData, compResp) = try? await session.data(from: compURL),
-                let compHTTP = compResp as? HTTPURLResponse, compHTTP.statusCode == 200,
-                let parsed = try? JSONDecoder().decode(InstatusComponentsResponse.self, from: compData)
-            {
-                components = flattenInstatusComponents(parsed.components)
-            }
+        var components: [InstatusComponent] = []
+        if let compData = try? await fetchData("\(baseURL)/api/v2/components.json"),
+            let parsed = try? JSONDecoder().decode(InstatusComponentsResponse.self, from: compData)
+        {
+            components = parsed.components
         }
 
-        let indicator = mapInstatusPageStatus(instatus.page.status)
-        let description = mapInstatusDescription(instatus.page.status)
-
-        return SPSummary(
-            page: SPPage(id: baseURL, name: instatus.page.name, url: instatus.page.url, updatedAt: "", timeZone: nil),
-            status: SPStatus(indicator: indicator, description: description),
-            components: components,
-            incidents: []
-        )
+        return SPSummary.fromInstatus(instatus, components: components, baseURL: baseURL)
     }
 
-    private func flattenInstatusComponents(_ components: [InstatusComponent], position: inout Int) -> [SPComponent] {
-        var result: [SPComponent] = []
-        for comp in components {
-            let mapped = SPComponent(
-                id: comp.id,
-                name: comp.name,
-                status: mapInstatusComponentStatus(comp.status),
-                description: comp.description,
-                position: position,
-                groupId: nil
-            )
-            position += 1
-            result.append(mapped)
-            if !comp.children.isEmpty {
-                result += flattenInstatusComponents(comp.children, position: &position)
-            }
-        }
-        return result
-    }
-
-    private func flattenInstatusComponents(_ components: [InstatusComponent]) -> [SPComponent] {
-        var pos = 0
-        return flattenInstatusComponents(components, position: &pos)
-    }
-
-    private func mapInstatusPageStatus(_ status: String) -> String {
-        ["UP": "none", "HASISSUES": "minor", "UNDERMAINTENANCE": "minor"][status, default: "major"]
-    }
-
-    private func mapInstatusDescription(_ status: String) -> String {
-        let map = ["UP": "All systems operational", "HASISSUES": "Experiencing issues", "UNDERMAINTENANCE": "Under maintenance"]
-        return map[status, default: "Experiencing issues"]
-    }
-
-    private func mapInstatusComponentStatus(_ status: String) -> String {
-        let map = [
-            "OPERATIONAL": "operational",
-            "DEGRADEDPERFORMANCE": "degraded_performance",
-            "PARTIALOUTAGE": "partial_outage",
-            "MAJOROUTAGE": "major_outage",
-            "UNDERMAINTENANCE": "degraded_performance",
-        ]
-        return map[status, default: status.lowercased()]
-    }
-
-    // MARK: - Gatus Fetch + Mapping
+    // MARK: - Gatus Fetch
 
     func fetchGatus(baseURL: String) async throws -> SPSummary {
         let pageSize = 100
         var endpoints: [GatusEndpointStatus] = []
         for page in 1...5 {
-            let (data, _) = try await withRetry {
-                let url = URL(string: "\(baseURL)/api/v1/endpoints/statuses?page=\(page)&pageSize=\(pageSize)")!
-                return try await self.session.data(from: url)
+            let data = try await withRetry {
+                try await self.fetchData("\(baseURL)/api/v1/endpoints/statuses?page=\(page)&pageSize=\(pageSize)")
             }
             let batch = try JSONDecoder().decode([GatusEndpointStatus].self, from: data)
             endpoints += batch

--- a/Sources/StatusService.swift
+++ b/Sources/StatusService.swift
@@ -42,6 +42,14 @@ final class StatusService: ObservableObject {
         historyStore.pruneOlderThan(Date().addingTimeInterval(-30 * 24 * 60 * 60))
         history = historyStore.data
         loadSources()
+        // Seed last-known indicators from persisted history so relaunching
+        // doesn't re-notify for incidents that were already seen (and does
+        // notify for changes that happened while the app was closed).
+        for source in sources {
+            if let last = history[source.id]?.last {
+                previousIndicators[source.id] = last.indicator
+            }
+        }
         // Ensure notification delegate is wired before any refresh sends notifications
         _ = NotificationManager.shared
         Task { await refreshAll() }
@@ -149,6 +157,10 @@ final class StatusService: ObservableObject {
                 incidents = []
             }
 
+            // The source may have been removed while the fetch was in flight;
+            // recording then would resurrect its state and history.
+            guard states[source.id] != nil else { return }
+
             let newIndicator = summary.status.indicator
             let oldIndicator = previousIndicators[source.id]
 
@@ -183,7 +195,11 @@ final class StatusService: ObservableObject {
         newIndicator: String, oldIndicator: String?
     ) {
         let newSev = severityFor(newIndicator)
-        guard newSev >= source.alertLevel.minimumSeverity else { return }
+        // Gate on the transition's peak severity: a recovery has newSev == 0,
+        // but should still alert when the incident it clears was above the
+        // threshold — otherwise "Recovered" notifications can never fire.
+        let peakSev = max(newSev, oldIndicator.map(severityFor) ?? -1)
+        guard peakSev >= source.alertLevel.minimumSeverity else { return }
 
         let name = source.name
         let desc = summary.status.description
@@ -253,6 +269,12 @@ final class StatusService: ObservableObject {
             providerCache.removeValue(forKey: oldID)
             historyStore.removeSource(oldID)
         }
+        // A re-imported source can keep its id but change URL — the cached
+        // provider is then stale.
+        let oldURLs = Dictionary(uniqueKeysWithValues: sources.map { ($0.id, $0.baseURL) })
+        for newSource in newSources where oldURLs[newSource.id] != newSource.baseURL {
+            providerCache.removeValue(forKey: newSource.id)
+        }
         history = historyStore.data
 
         sources = newSources
@@ -261,7 +283,9 @@ final class StatusService: ObservableObject {
     }
 
     func addSource(name: String, baseURL: String, group: String? = nil) {
-        let source = StatusSource(name: name, baseURL: baseURL, group: group, sortOrder: sources.count)
+        let storedLevel = UserDefaults.standard.string(forKey: "defaultAlertLevel")
+        let alertLevel = storedLevel.flatMap(AlertLevel.init(rawValue:)) ?? .all
+        let source = StatusSource(name: name, baseURL: baseURL, alertLevel: alertLevel, group: group, sortOrder: sources.count)
         sources.append(source)
         persistSources()
         Task { await refresh(source: source) }

--- a/Sources/UpdateChecker.swift
+++ b/Sources/UpdateChecker.swift
@@ -37,8 +37,8 @@ final class UpdateChecker: ObservableObject {
     }()
 
     init() {
-        Task { await checkForUpdates() }
         if autoCheckEnabled {
+            Task { await checkForUpdates() }
             startNightlyTimer()
         }
     }
@@ -162,12 +162,11 @@ final class UpdateChecker: ObservableObject {
                 return
             }
 
-            // Replace current app
+            // Replace current app atomically — if the swap fails, the current
+            // bundle is left untouched instead of already sitting in the Trash.
             let currentAppPath = Bundle.main.bundlePath
             let currentAppURL = URL(fileURLWithPath: currentAppPath)
-            var trashedURL: NSURL?
-            try FileManager.default.trashItem(at: currentAppURL, resultingItemURL: &trashedURL)
-            try FileManager.default.moveItem(at: newApp, to: currentAppURL)
+            _ = try FileManager.default.replaceItemAt(currentAppURL, withItemAt: newApp)
 
             // Clean up temp directory
             try? FileManager.default.removeItem(at: tempDir)

--- a/Sources/WebhookManager.swift
+++ b/Sources/WebhookManager.swift
@@ -72,7 +72,7 @@ final class WebhookManager: ObservableObject {
             severity: "minor",
             event: "degraded",
             url: "https://github.com/alexnodeland/StatusBar",
-            timestamp: ISO8601DateFormatter().string(from: Date()),
+            timestamp: isoFormatterNoFrac.string(from: Date()),
             components: ["API", "Dashboard"]
         )
         await send(config: config, event: event)

--- a/Tests/HistoryStoreTests.swift
+++ b/Tests/HistoryStoreTests.swift
@@ -165,12 +165,12 @@ final class HistoryStoreTests: XCTestCase {
     // MARK: - Migration
 
     @MainActor
-    func testMigrateFromAppStorage() {
+    func testMigrateFromAppStorage() throws {
         let id = UUID()
         let checkpoint = StatusCheckpoint(date: Date(timeIntervalSince1970: 1700000000), indicator: "minor")
         var legacy: [String: [StatusCheckpoint]] = [:]
         legacy[id.uuidString] = [checkpoint]
-        let json = String(data: try! JSONEncoder().encode(legacy), encoding: .utf8)!
+        let json = String(data: try JSONEncoder().encode(legacy), encoding: .utf8)!
 
         store.migrateFromAppStorage(json)
 

--- a/Tests/ModelsTests.swift
+++ b/Tests/ModelsTests.swift
@@ -14,9 +14,9 @@ final class ModelsTests: XCTestCase {
 
     // MARK: - Atlassian Models
 
-    func testSPSummaryDecodeFullFixture() {
+    func testSPSummaryDecodeFullFixture() throws {
         let data = loadFixture("atlassian_summary.json")
-        let summary = try! JSONDecoder().decode(SPSummary.self, from: data)
+        let summary = try JSONDecoder().decode(SPSummary.self, from: data)
         XCTAssertEqual(summary.page.id, "kctbh9vrtdwd")
         XCTAssertEqual(summary.page.name, "GitHub")
         XCTAssertEqual(summary.page.timeZone, "Etc/UTC")
@@ -26,39 +26,39 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(summary.incidents.count, 1)
     }
 
-    func testSPSummaryDecodeMissingArraysDefaultToEmpty() {
+    func testSPSummaryDecodeMissingArraysDefaultToEmpty() throws {
         let json = """
             {
                 "page": {"id":"p1","name":"Test","url":"https://test.com","updated_at":"2024-01-01T00:00:00Z"},
                 "status": {"indicator":"none","description":"All good"}
             }
             """.data(using: .utf8)!
-        let summary = try! JSONDecoder().decode(SPSummary.self, from: json)
+        let summary = try JSONDecoder().decode(SPSummary.self, from: json)
         XCTAssertEqual(summary.components.count, 0)
         XCTAssertEqual(summary.incidents.count, 0)
     }
 
-    func testSPPageCodingKeys() {
+    func testSPPageCodingKeys() throws {
         let json = """
             {"id":"p1","name":"Test","url":"https://test.com","updated_at":"2024-01-01T00:00:00Z","time_zone":"US/Pacific"}
             """.data(using: .utf8)!
-        let page = try! JSONDecoder().decode(SPPage.self, from: json)
+        let page = try JSONDecoder().decode(SPPage.self, from: json)
         XCTAssertEqual(page.updatedAt, "2024-01-01T00:00:00Z")
         XCTAssertEqual(page.timeZone, "US/Pacific")
     }
 
-    func testSPComponentCodingKeys() {
+    func testSPComponentCodingKeys() throws {
         let json = """
             {"id":"c1","name":"API","status":"operational","description":null,"position":1,"group_id":"g1"}
             """.data(using: .utf8)!
-        let component = try! JSONDecoder().decode(SPComponent.self, from: json)
+        let component = try JSONDecoder().decode(SPComponent.self, from: json)
         XCTAssertEqual(component.groupId, "g1")
         XCTAssertEqual(component.position, 1)
     }
 
-    func testSPIncidentWithUpdates() {
+    func testSPIncidentWithUpdates() throws {
         let data = loadFixture("atlassian_summary.json")
-        let summary = try! JSONDecoder().decode(SPSummary.self, from: data)
+        let summary = try JSONDecoder().decode(SPSummary.self, from: data)
         let incident = summary.incidents[0]
         XCTAssertEqual(incident.id, "inc1")
         XCTAssertEqual(incident.name, "Elevated error rates")
@@ -69,9 +69,9 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(incident.incidentUpdates[0].body, "We are investigating elevated error rates.")
     }
 
-    func testSPIncidentsResponse() {
+    func testSPIncidentsResponse() throws {
         let data = loadFixture("atlassian_incidents.json")
-        let response = try! JSONDecoder().decode(SPIncidentsResponse.self, from: data)
+        let response = try JSONDecoder().decode(SPIncidentsResponse.self, from: data)
         XCTAssertEqual(response.page.id, "kctbh9vrtdwd")
         XCTAssertEqual(response.incidents.count, 2)
         XCTAssertEqual(response.incidents[0].id, "inc1")
@@ -81,9 +81,9 @@ final class ModelsTests: XCTestCase {
 
     // MARK: - incident.io Models
 
-    func testIIOWidgetResponseDecode() {
+    func testIIOWidgetResponseDecode() throws {
         let data = loadFixture("incidentio_widget.json")
-        let widget = try! JSONDecoder().decode(IIOWidgetResponse.self, from: data)
+        let widget = try JSONDecoder().decode(IIOWidgetResponse.self, from: data)
         XCTAssertEqual(widget.ongoingIncidents?.count, 1)
         XCTAssertEqual(widget.inProgressMaintenances?.count, 1)
         XCTAssertEqual(widget.scheduledMaintenances?.count, 1)
@@ -91,19 +91,19 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(widget.ongoingIncidents?[0].affectedComponents?.count, 2)
     }
 
-    func testIIOWidgetResponseEmptyJSON() {
+    func testIIOWidgetResponseEmptyJSON() throws {
         let json = "{}".data(using: .utf8)!
-        let widget = try! JSONDecoder().decode(IIOWidgetResponse.self, from: json)
+        let widget = try JSONDecoder().decode(IIOWidgetResponse.self, from: json)
         XCTAssertNil(widget.ongoingIncidents)
         XCTAssertNil(widget.inProgressMaintenances)
         XCTAssertNil(widget.scheduledMaintenances)
     }
 
-    func testIIOIncidentOptionalFields() {
+    func testIIOIncidentOptionalFields() throws {
         let json = """
             {"id":"x","name":null,"status":null,"last_update_message":null,"affected_components":null,"created_at":null,"updated_at":null}
             """.data(using: .utf8)!
-        let incident = try! JSONDecoder().decode(IIOIncident.self, from: json)
+        let incident = try JSONDecoder().decode(IIOIncident.self, from: json)
         XCTAssertEqual(incident.id, "x")
         XCTAssertNil(incident.name)
         XCTAssertNil(incident.status)
@@ -113,17 +113,17 @@ final class ModelsTests: XCTestCase {
 
     // MARK: - Instatus Models
 
-    func testInstatusSummaryDecode() {
+    func testInstatusSummaryDecode() throws {
         let data = loadFixture("instatus_summary.json")
-        let summary = try! JSONDecoder().decode(InstatusSummary.self, from: data)
+        let summary = try JSONDecoder().decode(InstatusSummary.self, from: data)
         XCTAssertEqual(summary.page.name, "Acme Status")
         XCTAssertEqual(summary.page.url, "https://status.acme.com")
         XCTAssertEqual(summary.page.status, "UP")
     }
 
-    func testInstatusComponentsDecode() {
+    func testInstatusComponentsDecode() throws {
         let data = loadFixture("instatus_components.json")
-        let response = try! JSONDecoder().decode(InstatusComponentsResponse.self, from: data)
+        let response = try JSONDecoder().decode(InstatusComponentsResponse.self, from: data)
         XCTAssertEqual(response.components.count, 2)
         XCTAssertEqual(response.components[0].name, "API")
         XCTAssertTrue(response.components[0].isParent)
@@ -131,9 +131,9 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(response.components[1].status, "MAJOROUTAGE")
     }
 
-    func testInstatusNestedChildren() {
+    func testInstatusNestedChildren() throws {
         let data = loadFixture("instatus_components.json")
-        let response = try! JSONDecoder().decode(InstatusComponentsResponse.self, from: data)
+        let response = try JSONDecoder().decode(InstatusComponentsResponse.self, from: data)
         let apiComp = response.components[0]
         XCTAssertEqual(apiComp.children.count, 2)
         XCTAssertEqual(apiComp.children[0].name, "REST API")
@@ -144,9 +144,9 @@ final class ModelsTests: XCTestCase {
 
     // MARK: - Gatus Models
 
-    func testGatusEndpointStatusDecode() {
+    func testGatusEndpointStatusDecode() throws {
         let data = loadFixture("gatus_statuses.json")
-        let endpoints = try! JSONDecoder().decode([GatusEndpointStatus].self, from: data)
+        let endpoints = try JSONDecoder().decode([GatusEndpointStatus].self, from: data)
         XCTAssertEqual(endpoints.count, 3)
         XCTAssertEqual(endpoints[0].name, "frontend")
         XCTAssertEqual(endpoints[0].group, "core")
@@ -155,18 +155,18 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(endpoints[2].results.count, 0)
     }
 
-    func testGatusEndpointStatusMissingResultsDefaultsToEmpty() {
+    func testGatusEndpointStatusMissingResultsDefaultsToEmpty() throws {
         let json = """
             [{"name":"db","group":"infra","key":"infra_db"}]
             """.data(using: .utf8)!
-        let endpoints = try! JSONDecoder().decode([GatusEndpointStatus].self, from: json)
+        let endpoints = try JSONDecoder().decode([GatusEndpointStatus].self, from: json)
         XCTAssertEqual(endpoints[0].results.count, 0)
         XCTAssertNil(endpoints[0].latestResult)
     }
 
-    func testGatusLatestResultIsLast() {
+    func testGatusLatestResultIsLast() throws {
         let data = loadFixture("gatus_statuses.json")
-        let endpoints = try! JSONDecoder().decode([GatusEndpointStatus].self, from: data)
+        let endpoints = try JSONDecoder().decode([GatusEndpointStatus].self, from: data)
         // Gatus appends results chronologically; the last entry is the newest check
         XCTAssertEqual(endpoints[0].latestResult?.success, true)
         XCTAssertEqual(endpoints[1].latestResult?.success, false)
@@ -179,9 +179,9 @@ final class ModelsTests: XCTestCase {
         XCTAssertEqual(ungrouped.displayName, "backups")
     }
 
-    func testGatusSummaryMappingPartialOutage() {
+    func testGatusSummaryMappingPartialOutage() throws {
         let data = loadFixture("gatus_statuses.json")
-        let endpoints = try! JSONDecoder().decode([GatusEndpointStatus].self, from: data)
+        let endpoints = try JSONDecoder().decode([GatusEndpointStatus].self, from: data)
         let summary = SPSummary.fromGatus(endpoints, baseURL: "https://status.example.org")
         XCTAssertEqual(summary.status.indicator, "major")
         XCTAssertEqual(summary.status.description, "1 of 2 endpoints down")
@@ -221,9 +221,9 @@ final class ModelsTests: XCTestCase {
 
     // MARK: - GitHub Models
 
-    func testGitHubReleaseFullFixture() {
+    func testGitHubReleaseFullFixture() throws {
         let data = loadFixture("github_release.json")
-        let release = try! JSONDecoder().decode(GitHubRelease.self, from: data)
+        let release = try JSONDecoder().decode(GitHubRelease.self, from: data)
         XCTAssertEqual(release.tagName, "v1.2.3")
         XCTAssertEqual(release.name, "Release v1.2.3")
         XCTAssertEqual(release.htmlUrl, "https://github.com/alexnodeland/StatusBar/releases/tag/v1.2.3")
@@ -232,11 +232,11 @@ final class ModelsTests: XCTestCase {
         XCTAssertTrue(release.assets[0].browserDownloadUrl.contains("v1.2.3"))
     }
 
-    func testGitHubReleaseOptionalNameEmptyAssets() {
+    func testGitHubReleaseOptionalNameEmptyAssets() throws {
         let json = """
             {"tag_name":"v0.1.0","name":null,"html_url":"https://example.com","assets":[]}
             """.data(using: .utf8)!
-        let release = try! JSONDecoder().decode(GitHubRelease.self, from: json)
+        let release = try JSONDecoder().decode(GitHubRelease.self, from: json)
         XCTAssertEqual(release.tagName, "v0.1.0")
         XCTAssertNil(release.name)
         XCTAssertEqual(release.assets.count, 0)

--- a/Tests/ProviderMappingTests.swift
+++ b/Tests/ProviderMappingTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import XCTest
+
+// MARK: - ProviderMappingTests
+
+final class ProviderMappingTests: XCTestCase {
+
+    // MARK: - incident.io Mapping
+
+    func testFromIncidentIOWidgetFixture() throws {
+        let widget = try JSONDecoder().decode(IIOWidgetResponse.self, from: loadFixture("incidentio_widget.json"))
+        let (summary, incidents) = SPSummary.fromIncidentIOWidget(widget, baseURL: "https://status.example.com")
+
+        // Ongoing + in-progress maintenances are included; scheduled are not
+        XCTAssertEqual(incidents.count, 2)
+        XCTAssertEqual(summary.status.indicator, "major")  // "investigating" present
+        XCTAssertEqual(summary.status.description, "2 active incidents")
+        XCTAssertEqual(summary.page.id, "https://status.example.com")
+
+        let api = incidents[0]
+        XCTAssertEqual(api.id, "iio-1")
+        XCTAssertEqual(api.impact, "major")
+        XCTAssertEqual(api.incidentUpdates.count, 1)
+        XCTAssertEqual(api.incidentUpdates[0].body, "We are investigating API issues.")
+
+        let maintenance = incidents[1]
+        XCTAssertEqual(maintenance.impact, "minor")  // "monitoring"
+    }
+
+    func testFromIncidentIOWidgetEmpty() throws {
+        let widget = try JSONDecoder().decode(IIOWidgetResponse.self, from: Data("{}".utf8))
+        let (summary, incidents) = SPSummary.fromIncidentIOWidget(widget, baseURL: "https://s.example.com")
+        XCTAssertEqual(incidents.count, 0)
+        XCTAssertEqual(summary.status.indicator, "none")
+        XCTAssertEqual(summary.status.description, "All systems operational")
+    }
+
+    func testDeriveIncidentIOImpact() {
+        XCTAssertEqual(deriveIncidentIOImpact(from: "investigating"), "major")
+        XCTAssertEqual(deriveIncidentIOImpact(from: "Identified"), "major")
+        XCTAssertEqual(deriveIncidentIOImpact(from: "monitoring"), "minor")
+        XCTAssertEqual(deriveIncidentIOImpact(from: "resolved"), "none")
+        XCTAssertEqual(deriveIncidentIOImpact(from: "postmortem"), "none")
+        XCTAssertEqual(deriveIncidentIOImpact(from: "something-else"), "minor")
+    }
+
+    func testDeriveIncidentIOIndicator() {
+        XCTAssertEqual(deriveIncidentIOIndicator(from: []), "none")
+        let monitoring = IIOIncident(
+            id: "a", name: "A", status: "monitoring", lastUpdateMessage: nil,
+            affectedComponents: nil, createdAt: nil, updatedAt: nil)
+        XCTAssertEqual(deriveIncidentIOIndicator(from: [monitoring]), "minor")
+        let investigating = IIOIncident(
+            id: "b", name: "B", status: "investigating", lastUpdateMessage: nil,
+            affectedComponents: nil, createdAt: nil, updatedAt: nil)
+        XCTAssertEqual(deriveIncidentIOIndicator(from: [monitoring, investigating]), "major")
+    }
+
+    // MARK: - Instatus Mapping
+
+    func testFromInstatusFixture() throws {
+        let instatus = try JSONDecoder().decode(InstatusSummary.self, from: loadFixture("instatus_summary.json"))
+        let comps = try JSONDecoder().decode(InstatusComponentsResponse.self, from: loadFixture("instatus_components.json"))
+        let summary = SPSummary.fromInstatus(instatus, components: comps.components, baseURL: "https://status.acme.com")
+
+        XCTAssertEqual(summary.page.name, "Acme Status")
+        XCTAssertEqual(summary.status.indicator, "none")  // "UP"
+        XCTAssertEqual(summary.status.description, "All systems operational")
+
+        // Nested children are flattened depth-first with sequential positions
+        XCTAssertEqual(summary.components.map(\.id), ["ic1", "ic1a", "ic1b", "ic2"])
+        XCTAssertEqual(summary.components.map(\.position), [0, 1, 2, 3])
+        XCTAssertEqual(summary.components[2].status, "degraded_performance")
+        XCTAssertEqual(summary.components[3].status, "major_outage")
+        XCTAssertEqual(summary.incidents.count, 0)
+    }
+
+    func testMapInstatusPageStatus() {
+        XCTAssertEqual(mapInstatusPageStatus("UP"), "none")
+        XCTAssertEqual(mapInstatusPageStatus("HASISSUES"), "minor")
+        XCTAssertEqual(mapInstatusPageStatus("UNDERMAINTENANCE"), "minor")
+        XCTAssertEqual(mapInstatusPageStatus("SOMETHINGELSE"), "major")
+    }
+
+    func testMapInstatusDescription() {
+        XCTAssertEqual(mapInstatusDescription("UP"), "All systems operational")
+        XCTAssertEqual(mapInstatusDescription("HASISSUES"), "Experiencing issues")
+        XCTAssertEqual(mapInstatusDescription("UNDERMAINTENANCE"), "Under maintenance")
+        XCTAssertEqual(mapInstatusDescription("UNKNOWN"), "Experiencing issues")
+    }
+
+    func testMapInstatusComponentStatus() {
+        XCTAssertEqual(mapInstatusComponentStatus("OPERATIONAL"), "operational")
+        XCTAssertEqual(mapInstatusComponentStatus("DEGRADEDPERFORMANCE"), "degraded_performance")
+        XCTAssertEqual(mapInstatusComponentStatus("PARTIALOUTAGE"), "partial_outage")
+        XCTAssertEqual(mapInstatusComponentStatus("MAJOROUTAGE"), "major_outage")
+        XCTAssertEqual(mapInstatusComponentStatus("UNDERMAINTENANCE"), "degraded_performance")
+        XCTAssertEqual(mapInstatusComponentStatus("NEWSTATUS"), "newstatus")
+    }
+
+    // MARK: - Fetch Error Retryability
+
+    func testFetchErrorRetryability() {
+        XCTAssertFalse(FetchError.invalidURL.isRetryable)
+        XCTAssertFalse(FetchError.httpStatus(404).isRetryable)
+        XCTAssertFalse(FetchError.httpStatus(429).isRetryable)
+        XCTAssertTrue(FetchError.httpStatus(500).isRetryable)
+        XCTAssertTrue(FetchError.httpStatus(503).isRetryable)
+    }
+
+    func testIsRetryableErrorClassification() {
+        XCTAssertFalse(isRetryableError(FetchError.invalidURL))
+        XCTAssertFalse(
+            isRetryableError(
+                DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "bad"))))
+        XCTAssertTrue(isRetryableError(URLError(.timedOut)))
+        XCTAssertTrue(isRetryableError(FetchError.httpStatus(502)))
+    }
+
+    func testWithRetryDoesNotRetryTerminalErrors() async {
+        var attempts = 0
+        do {
+            _ = try await withRetry(maxAttempts: 3, baseDelay: 0.001, maxDelay: 0.001) { () -> Int in
+                attempts += 1
+                throw FetchError.httpStatus(404)
+            }
+            XCTFail("Expected throw")
+        } catch {
+            XCTAssertEqual(error as? FetchError, .httpStatus(404))
+        }
+        XCTAssertEqual(attempts, 1)
+    }
+
+    func testWithRetryRetriesTransientErrors() async {
+        var attempts = 0
+        do {
+            _ = try await withRetry(maxAttempts: 3, baseDelay: 0.001, maxDelay: 0.001) { () -> Int in
+                attempts += 1
+                throw FetchError.httpStatus(500)
+            }
+            XCTFail("Expected throw")
+        } catch {}
+        XCTAssertEqual(attempts, 3)
+    }
+}

--- a/Tests/WebhookManagerTests.swift
+++ b/Tests/WebhookManagerTests.swift
@@ -5,6 +5,28 @@ import XCTest
 
 final class WebhookManagerTests: XCTestCase {
 
+    // Config tests mutate the WebhookManager.shared singleton, which persists
+    // to real UserDefaults — snapshot and restore so failures don't leak
+    // webhook configs into later runs (or the developer's installed app).
+    private var savedConfigsJSON: String?
+
+    override func setUp() {
+        super.setUp()
+        savedConfigsJSON = UserDefaults.standard.string(forKey: "webhookConfigs")
+    }
+
+    override func tearDown() {
+        if let savedConfigsJSON {
+            UserDefaults.standard.set(savedConfigsJSON, forKey: "webhookConfigs")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "webhookConfigs")
+        }
+        MainActor.assumeIsolated {
+            WebhookManager.shared.loadConfigs()
+        }
+        super.tearDown()
+    }
+
     // MARK: - Test Helpers
 
     private func makeEvent(

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,9 @@
 
 set -euo pipefail
 
+# Run from the repo root regardless of invocation directory
+cd "$(dirname "$0")"
+
 APP_NAME="StatusBar"
 BUILD_DIR="./build"
 APP_BUNDLE="${BUILD_DIR}/${APP_NAME}.app"
@@ -117,8 +120,8 @@ if [ -n "$VERSION" ]; then
     # Strip leading 'v' if present (v1.0.0 → 1.0.0)
     CLEAN_VERSION="${VERSION#v}"
     echo "  Setting version to ${CLEAN_VERSION}..."
-    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${CLEAN_VERSION}" "${CONTENTS}/Info.plist"
-    /usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${CLEAN_VERSION}" "${CONTENTS}/Info.plist"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString '${CLEAN_VERSION}'" "${CONTENTS}/Info.plist"
+    /usr/libexec/PlistBuddy -c "Set :CFBundleVersion '${CLEAN_VERSION}'" "${CONTENTS}/Info.plist"
 fi
 
 # Copy app icon if it exists
@@ -128,7 +131,8 @@ fi
 
 # Copy bundled images
 for img in *.png; do
-    [ -f "$img" ] && [ "$img" != "icon.png" ] && cp "$img" "${RESOURCES}/"
+    case "$img" in icon.png|github.png) continue ;; esac
+    [ -f "$img" ] && cp "$img" "${RESOURCES}/"
 done
 
 # Copy scripting definition for AppleScript support

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,8 +57,8 @@
         </a>
       </div>
       <div class="hero-badges">
-        <img src="https://img.shields.io/badge/macOS-14%2B-blue" alt="macOS 14+" width="76" height="20">
-        <img src="https://img.shields.io/badge/Swift-5.9%2B-orange" alt="Swift 5.9+" width="80" height="20">
+        <img src="https://img.shields.io/badge/macOS-26%2B-blue" alt="macOS 26+" width="76" height="20">
+        <img src="https://img.shields.io/badge/Swift-6-orange" alt="Swift 6" width="80" height="20">
         <img src="https://img.shields.io/github/v/release/alexnodeland/StatusBar" alt="GitHub Release" width="100" height="20">
       </div>
     </div>
@@ -143,10 +143,10 @@
                   <tr><th>Platform</th><th>Payload shape</th></tr>
                 </thead>
                 <tbody>
-                  <tr><td><code>Slack</code></td><td><code>{ "text": "..." }</code></td></tr>
-                  <tr><td><code>Discord</code></td><td><code>{ "content": "..." }</code></td></tr>
-                  <tr><td><code>Teams</code></td><td><code>{ "@type": "MessageCard", ... }</code></td></tr>
-                  <tr><td><code>Generic</code></td><td><code>{ "source", "title", "body" }</code></td></tr>
+                  <tr><td><code>Slack</code></td><td>Block Kit &mdash; <code>{ "attachments": [{ "color", "blocks" }] }</code></td></tr>
+                  <tr><td><code>Discord</code></td><td>Embeds &mdash; <code>{ "embeds": [{ "title", "description", "color", "fields" }] }</code></td></tr>
+                  <tr><td><code>Teams</code></td><td>Adaptive Card &mdash; <code>{ "type": "message", "attachments": [{ "content": { "type": "AdaptiveCard" } }] }</code></td></tr>
+                  <tr><td><code>Generic</code></td><td>Flat JSON &mdash; <code>{ "source", "title", "body", "severity", "event", "url", "timestamp", "components" }</code></td></tr>
                 </tbody>
               </table>
               <p class="hook-table-note">Webhooks fire on every status change. Each webhook has an enable/disable toggle and a 10-second request timeout.</p>
@@ -385,7 +385,7 @@ end tell</code></pre>
       <div class="steps">
         <div class="glass-card step">
           <span class="step-number">1</span>
-          <span class="step-text">Download <strong>StatusBar-vX.Y.Z-universal.zip</strong> from the <a href="https://github.com/alexnodeland/StatusBar/releases/latest">Releases page</a></span>
+          <span class="step-text">Install with <code>brew install --cask alexnodeland/tap/statusbar</code>, or download <strong>StatusBar-vX.Y.Z.zip</strong> from the <a href="https://github.com/alexnodeland/StatusBar/releases/latest">Releases page</a></span>
         </div>
         <div class="glass-card step">
           <span class="step-number">2</span>
@@ -420,7 +420,7 @@ open ./build/StatusBar.app</code></pre>
           <div class="code-block-wrapper">
             <pre><code>swiftc StatusBarApp.swift -parse-as-library \
   -o StatusBar -framework SwiftUI -framework AppKit \
-  -target arm64-apple-macosx14.0
+  -target arm64-apple-macosx26.0
 ./StatusBar</code></pre>
             <button class="copy-btn" aria-label="Copy code">Copy</button>
           </div>

--- a/test.sh
+++ b/test.sh
@@ -24,7 +24,9 @@ rm -rf "${BUILD_DIR}"
 mkdir -p "${BUNDLE_DIR}/Contents/MacOS"
 
 # Collect source files (exclude StatusBarApp.swift which has @main,
-# and HotkeyManager.swift which requires Carbon event loop at runtime)
+# HotkeyManager.swift which requires the Carbon event loop at runtime,
+# and AppleScriptBridge.swift whose scripting-command classes are only
+# referenced from the excluded StatusBarApp.swift)
 SOURCE_FILES=()
 for f in "${PROJECT_DIR}"/Sources/*.swift; do
     case "$(basename "$f")" in


### PR DESCRIPTION
## Summary

A full repo sweep (sources, tests, build scripts, workflows, docs) with every vetted finding fixed. Grouped by impact:

### Bugs users would hit

- **Recovery notifications never fired.** `notifyIfNeeded` gated on the *new* indicator's severity, which is 0 when a source recovers — so the "Recovered" notification, webhook, and hook paths were unreachable for every alert level. The gate now uses the transition's peak severity.
- **"New sources notify at" was a no-op.** The default alert level setting was written and exported but never read; `addSource` (Settings, catalog, URL scheme, AppleScript) now applies it.
- **Release signing/notarization steps never ran.** `if: env.APPLE_CERTIFICATE != ''` referenced env vars defined in that same step's `env:` block, which GitHub evaluates *after* the condition — so releases were always ad-hoc signed even with secrets configured. Now gated on the `secrets` context directly.
- **App advertised macOS 14 but requires macOS 26.** The binary uses Liquid Glass APIs and compiles with `-target macosx26.0`, yet `LSMinimumSystemVersion` said 14.0 — macOS 14–25 users could launch and crash. Plist, README/docs badges, and build snippets now all say macOS 26.
- **Auto-update trashed the running app before the replacement was in place** — a failed move left a broken install. Now uses an atomic `replaceItemAt` swap. The launch-time update check also now respects the "check automatically" setting.
- **Crash-prone force-unwrapped URLs** in all fetch paths (reachable via imported configs that bypass URL validation) replaced with typed `FetchError`s.

### Correctness & robustness

- HTTP status is checked before decoding; `withRetry` no longer burns retries+backoff on terminal errors (4xx, decode failures).
- Relaunching no longer re-notifies for incidents that were already seen (last-known indicators are seeded from persisted history).
- Removing a source mid-refresh no longer resurrects its state/history; re-imported sources with a changed URL invalidate the provider cache.
- Status history is flushed on quit (writes were debounced by 5s and lost).
- incident.io-compat sources no longer show "incident details not available" directly above the incident details.
- Removed the AWS catalog entry — not a supported provider, so one-click add always produced a permanently erroring source.

### CI / build

- All GitHub Actions bumped to Node 24 runtimes (checkout v7, cache v6, pages actions, gh-release v3) — fixes the deprecation warnings from the v0.2.0 release run.
- `build.sh`: no longer bundles the README screenshot into the app, `cd`s to the repo root, quotes PlistBuddy values.

### Tests & docs

- Provider mapping logic extracted to pure functions in `ProviderMappings.swift` and covered by 12 new tests (incident.io widget mapping, Instatus flattening/status maps, retry classification) — this was the app's core correctness surface with zero coverage. 194 tests total, all passing.
- Webhook config tests snapshot/restore real `UserDefaults` instead of mutating the developer's actual app settings; `try!` converted to throwing asserts so one bad fixture can't kill the whole run.
- Docs site webhook payload table now matches reality (Slack Block Kit, Discord embeds, Teams Adaptive Card — not the legacy shapes it claimed), release asset name corrected, Homebrew install added, AppleScript property table completed.

Considered and deliberately skipped: recording checkpoints only on status change (would skew the uptime fraction, which samples per refresh), Homebrew cache rework in CI, and hook-discovery caching (one directory listing per refresh interval is negligible).

## Test plan

- `make check` — 0 lint violations, format clean, 194/194 tests pass
- `make build` — app builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015b2b1TQZjDQnSsHCUpkFxC