### PR TITLE
fix: release workflow invalid — secrets context not allowed in step if

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ permissions:
 jobs:
   build-and-release:
     runs-on: macos-26
+    # The secrets context is unavailable in step-level `if:`; job-level env
+    # can read it, and step conditions can read job env.
+    env:
+      HAS_SIGNING_CERT: ${{ secrets.APPLE_CERTIFICATE != '' }}
+      HAS_NOTARIZE_CREDS: ${{ secrets.NOTARIZE_APPLE_ID != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -30,7 +35,7 @@ jobs:
           fi
 
       - name: Import signing certificate
-        if: ${{ secrets.APPLE_CERTIFICATE != '' }}
+        if: env.HAS_SIGNING_CERT == 'true'
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -47,7 +52,7 @@ jobs:
           security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain-db
 
       - name: Setup notarization profile
-        if: ${{ secrets.NOTARIZE_APPLE_ID != '' }}
+        if: env.HAS_NOTARIZE_CREDS == 'true'
         env:
           NOTARIZE_APPLE_ID: ${{ secrets.NOTARIZE_APPLE_ID }}
           NOTARIZE_PASSWORD: ${{ secrets.NOTARIZE_PASSWORD }}


### PR DESCRIPTION
## Summary

The signing-step fix in #23 replaced the never-true `if: env.APPLE_CERTIFICATE != ''` with `if: ${{ secrets.APPLE_CERTIFICATE != '' }}` — but GitHub does not expose the `secrets` context to step-level `if:` conditions, which made release.yml **unparseable**: every push since produced an instant-failure stub run, and pushing the `v0.2.1` tag triggered no release at all (that tag has been deleted and will be re-created on this fix).

The working pattern: job-level `env` **can** read secrets, and step `if:` **can** read job env — so the job now derives `HAS_SIGNING_CERT` / `HAS_NOTARIZE_CREDS` flags and the steps gate on those. This finally makes the signing/notarization steps run when the secrets are configured (they were silently skipped in every release to date).

All three workflows now validate clean with `actionlint`.

## Test plan

- `actionlint .github/workflows/*.yml` — clean
- After merge: re-tag `v0.2.1` and confirm the Release workflow actually runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015b2b1TQZjDQnSsHCUpkFxC