### PR TITLE
fix: production-grade responsive pass on the docs site

### DIFF
--- a/docs/script.js
+++ b/docs/script.js
@@ -9,14 +9,18 @@
   const links = document.getElementById('nav-links');
 
   if (toggle && links) {
+    toggle.setAttribute('aria-expanded', 'false');
+    toggle.setAttribute('aria-controls', 'nav-links');
     toggle.addEventListener('click', function () {
-      links.classList.toggle('open');
+      var open = links.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
     });
 
     // Close mobile nav when a link is clicked
     links.addEventListener('click', function (e) {
       if (e.target.tagName === 'A') {
         links.classList.remove('open');
+        toggle.setAttribute('aria-expanded', 'false');
       }
     });
   }
@@ -56,9 +60,12 @@
     var contentId = trigger.id.replace('-trigger', '-content');
     var content = document.getElementById(contentId);
     if (content) {
+      trigger.setAttribute('aria-expanded', 'false');
+      trigger.setAttribute('aria-controls', contentId);
       trigger.addEventListener('click', function () {
-        trigger.classList.toggle('open');
+        var open = trigger.classList.toggle('open');
         content.classList.toggle('open');
+        trigger.setAttribute('aria-expanded', open ? 'true' : 'false');
       });
     }
   });

--- a/docs/style.css
+++ b/docs/style.css
@@ -45,6 +45,9 @@
   --glow-orange: rgba(255, 159, 10, 0.6);
   --glow-red: rgba(255, 59, 48, 0.6);
 
+  /* Opaque copy-button surface (matches code chip over card over page) */
+  --copy-btn-bg: #232329;
+
   /* Layout */
   --max-width: 960px;
   --nav-height: 56px;
@@ -67,6 +70,7 @@
     --glow-yellow: rgba(255, 214, 10, 0.25);
     --glow-orange: rgba(255, 159, 10, 0.25);
     --glow-red: rgba(255, 59, 48, 0.25);
+    --copy-btn-bg: #e4e4e9;
   }
 }
 
@@ -353,16 +357,17 @@ section {
   margin-top: 48px;
 }
 
-.showcase-reverse {
-  direction: rtl;
+.showcase-reverse .showcase-image {
+  order: 2;
 }
 
-.showcase-reverse > * {
-  direction: ltr;
+.showcase-reverse .showcase-text {
+  order: 1;
 }
 
 .showcase-image {
   max-width: 380px;
+  min-width: 0;
 }
 
 .showcase-reverse .showcase-image {
@@ -370,6 +375,9 @@ section {
 }
 
 .screenshot {
+  display: block;
+  width: 100%;
+  height: auto;
   border-radius: 14px;
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35), 0 0 0 0.5px var(--glass-border);
 }
@@ -419,7 +427,8 @@ section {
 }
 
 .native-notification {
-  max-width: 380px;
+  max-width: min(380px, 100%);
+  height: auto;
   border-radius: 14px;
   box-shadow: 0 8px 28px rgba(0, 0, 0, 0.3), 0 0 0 0.5px var(--glass-border);
 }
@@ -437,8 +446,9 @@ section {
     text-align: center;
   }
 
-  .showcase-reverse {
-    direction: ltr;
+  .showcase-reverse .showcase-image,
+  .showcase-reverse .showcase-text {
+    order: initial;
   }
 
   .showcase-image {
@@ -529,8 +539,26 @@ section {
 }
 
 .url-example .code-block-wrapper pre {
-  padding: 8px 12px;
+  padding: 8px 58px 8px 12px;
   font-size: 0.75rem;
+}
+
+/* Right-edge fade so scrolled code disappears cleanly behind the Copy button */
+.url-example .code-block-wrapper::after {
+  content: "";
+  position: absolute;
+  top: 1px;
+  bottom: 1px;
+  right: 1px;
+  width: 64px;
+  border-radius: 0 var(--radius-small) var(--radius-small) 0;
+  background: linear-gradient(to right, transparent, var(--copy-btn-bg) 55%);
+  pointer-events: none;
+}
+
+.url-example .copy-btn {
+  z-index: 1;
+  box-shadow: none;
 }
 
 .url-label {
@@ -788,6 +816,19 @@ section {
 .code-block-wrapper {
   position: relative;
   margin: 16px 0;
+  max-width: 100%;
+  min-width: 0;
+}
+
+/* Grid/flex items default to min-width:auto, letting long code lines widen
+   the page — allow them to shrink so pre scrolls inside its card instead. */
+.url-examples-grid > *,
+.automate-row > *,
+.applescript-layout > *,
+.showcase > *,
+.glass-card,
+.url-example {
+  min-width: 0;
 }
 
 .code-block-wrapper pre {
@@ -807,7 +848,10 @@ section {
   position: absolute;
   top: 8px;
   right: 8px;
-  background: var(--glass-bg);
+  /* Opaque so code scrolled beneath never shows through, with a soft
+     fade on the leading edge */
+  background: var(--copy-btn-bg, #1e1e22);
+  box-shadow: -10px 0 10px -6px var(--copy-btn-bg, #1e1e22);
   border: 0.5px solid var(--glass-border);
   border-radius: var(--radius-small);
   color: var(--text-secondary);
@@ -1125,7 +1169,8 @@ section {
 
 .footer-links {
   display: flex;
-  gap: 24px;
+  flex-wrap: wrap;
+  gap: 12px 24px;
   justify-content: center;
   margin-bottom: 16px;
 }
@@ -1165,6 +1210,59 @@ section {
 
   .status-strip {
     gap: 12px;
+  }
+}
+
+/* --- FAQ Grid --- */
+.status-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 32px;
+}
+
+.status-card {
+  padding: 20px;
+}
+
+.status-card h3 {
+  font-size: 1rem;
+  margin-bottom: 8px;
+}
+
+.status-card p {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.status-card a {
+  color: var(--accent, #2f81f7);
+}
+
+@media (max-width: 768px) {
+  .status-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Reserve room for the floating Copy button so scrolled code never
+   slides underneath it */
+.code-block-wrapper pre {
+  padding-right: 64px;
+}
+
+/* Reduced motion: no smooth scrolling or animated transforms */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
   }
 }
 


### PR DESCRIPTION
## Summary

Full Playwright audit of the GitHub Pages site at 375/390/768/1280/1440px in both light and dark schemes, fixing everything found:

**Mobile (the big one):** the page had **160px of horizontal overflow** at 375px — long code lines in grid cards forced intrinsic widths (`min-width:auto` grid-item trap), the 6-link footer nav didn't wrap, and the notification screenshot had a fixed 380px width. All grid/flex children can now shrink so `pre` scrolls inside its card, the footer wraps, and images clamp to their containers. Verified `scrollWidth === viewport` at every tested size.

**Real rendering bug:** the FAQ section referenced `.status-grid`/`.status-card` classes that didn't exist in the CSS — it rendered as unstyled, run-together text. Now a proper 2-col grid (1-col mobile) of cards.

**Polish:**
- Copy buttons over scrollable code were translucent, so scrolled code showed through them — now opaque with a fade edge, plus a right-edge fade mask on the single-line URL chips.
- Replaced the `direction: rtl` column-swap hack with grid `order` (keeps DOM/reading order correct for screen readers).
- `prefers-reduced-motion` support (kills smooth-scroll + transitions).
- `aria-expanded`/`aria-controls` wired on the mobile nav toggle and all collapsible triggers.

## Test plan
- Playwright: no horizontal overflow at 375/390/768/1440; hamburger nav open/close verified; FAQ/URL-scheme/AppleScript sections visually reviewed at mobile; full-page light + dark screenshots reviewed at desktop and tablet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015b2b1TQZjDQnSsHCUpkFxC