### PR TITLE
feat: personal automation surface — status cache, CLI, App Intents, prompt integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to StatusBar. Full release notes with downloads live on the
   every poll — the interface for terminal tooling
 - Bundled `statusbar` CLI: status/list, `wait` (block until recovery),
   `prompt` glyph for status lines, and URL-scheme passthrough
+- Per-repo scoping: a `.statusbar` file lists a project's upstream
+  dependencies; `status` and `prompt` honor the nearest one
 - App Intents for Shortcuts and Spotlight: Get Worst Status, Get Source
   Status, Refresh Sources
 - Docs: terminal/prompt integration guides (starship, tmux, SketchyBar)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to StatusBar. Full release notes with downloads live on the
 [GitHub Releases page](https://github.com/alexnodeland/StatusBar/releases).
 
+## Unreleased
+
+- Status cache file at `~/.cache/statusbar/status.json`, refreshed on
+  every poll — the interface for terminal tooling
+- Bundled `statusbar` CLI: status/list, `wait` (block until recovery),
+  `prompt` glyph for status lines, and URL-scheme passthrough
+- App Intents for Shortcuts and Spotlight: Get Worst Status, Get Source
+  Status, Refresh Sources
+- Docs: terminal/prompt integration guides (starship, tmux, SketchyBar)
+
 ## v0.3.2 — 2026-07-20
 
 - Menu bar icon defaults to the monochrome status symbol (check /

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Universal binary — Apple Silicon and Intel. Updates arrive via `brew upgrade`,
 
 📣 **Webhooks** — push status changes to Slack (Block Kit), Discord (embeds), Microsoft Teams (Adaptive Cards), or any JSON endpoint — with per-webhook labels and real delivery feedback on test sends.
 
-⌨️ **At your fingertips** — a rebindable global hotkey (default `⌃⌥S`), a `statusbar://` URL scheme, script hooks, and a full AppleScript dictionary. Runs as a pure menu bar agent.
+⌨️ **At your fingertips** — a rebindable global hotkey (default `⌃⌥S`), a bundled CLI (`statusbar wait npm && npm publish`), Shortcuts/Spotlight intents, a `statusbar://` URL scheme, script hooks, and a full AppleScript dictionary. Runs as a pure menu bar agent.
 
 <div align="center"><br><img src="docs/tick-divider.svg" width="260" alt=""><br><br></div>
 
@@ -204,6 +204,41 @@ osascript -e 'tell application "StatusBar" to refresh'
 | `group` | text | Group name (empty string if ungrouped) |
 
 </details>
+
+## Terminal & Shortcuts
+
+The app writes a status snapshot to `~/.cache/statusbar/status.json` on every refresh. The bundled CLI reads it instantly:
+
+```bash
+sudo ln -sf /Applications/StatusBar.app/Contents/MacOS/statusbar-cli /usr/local/bin/statusbar
+
+statusbar status                   # all sources, colored, exit code 0/1
+statusbar status github --json     # one source, machine-readable
+statusbar wait npm && npm publish  # block until a source recovers
+statusbar prompt                   # "●" or "▲1" — for starship/tmux/SketchyBar
+```
+
+<details>
+<summary>Prompt integrations</summary>
+
+```toml
+# ~/.config/starship.toml
+[custom.statusbar]
+command = "statusbar prompt"
+when = true
+format = "[$output]($style) "
+style = "bold green"
+```
+
+```bash
+# ~/.tmux.conf
+set -g status-right '#(statusbar prompt) %H:%M'
+set -g status-interval 60
+```
+
+</details>
+
+StatusBar also exposes **App Intents** — *Get Worst Status*, *Get Source Status*, and *Refresh Sources* — for Shortcuts automations, Focus modes, and Spotlight.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,15 @@ set -g status-interval 60
 
 </details>
 
+Drop a `.statusbar` file in a repo (one source name per line, `#` comments) and `statusbar status` / `statusbar prompt` scope to **that project's** upstream dependencies — your prompt shows the health of what *this* codebase depends on. `--all` bypasses.
+
+```
+# .statusbar — upstream deps for this repo
+GitHub
+npm
+Vercel
+```
+
 StatusBar also exposes **App Intents** — *Get Worst Status*, *Get Source Status*, and *Refresh Sources* — for Shortcuts automations, Focus modes, and Spotlight.
 
 ## Development

--- a/Sources/Intents.swift
+++ b/Sources/Intents.swift
@@ -1,0 +1,139 @@
+// Intents.swift
+// App Intents: StatusBar in Shortcuts, Spotlight, and personal automations.
+// Reads the live service when the app is running, the status cache otherwise.
+
+import AppIntents
+import Foundation
+
+// MARK: - Helpers
+
+private func liveOrCachedSnapshot() async -> StatusCacheSnapshot? {
+    if let service = AppRuntime.service {
+        return await MainActor.run {
+            StatusCache.snapshot(sources: service.sources, states: service.states)
+        }
+    }
+    return StatusCache().read()
+}
+
+// MARK: - Get Worst Status
+
+struct GetWorstStatusIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Worst Status"
+    static let description = IntentDescription(
+        "The worst status level across all monitored sources: none, minor, major, critical, or unknown."
+    )
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
+        let snapshot = await liveOrCachedSnapshot()
+        let worst = snapshot?.worst ?? "unknown"
+        let issues = snapshot?.issueCount ?? 0
+        let dialog: IntentDialog =
+            issues == 0
+            ? "All systems operational."
+            : "\(issues) source\(issues == 1 ? "" : "s") with issues — worst is \(worst)."
+        return .result(value: worst, dialog: dialog)
+    }
+}
+
+// MARK: - Get Source Status
+
+struct GetSourceStatusIntent: AppIntent {
+    static let title: LocalizedStringResource = "Get Source Status"
+    static let description = IntentDescription(
+        "The current status of one monitored source, by name."
+    )
+
+    @Parameter(title: "Source name")
+    var name: String
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Get status of \(\.$name)")
+    }
+
+    func perform() async throws -> some IntentResult & ReturnsValue<String> & ProvidesDialog {
+        guard let snapshot = await liveOrCachedSnapshot() else {
+            throw IntentError.noData
+        }
+        guard
+            let source = snapshot.sources.first(where: {
+                $0.name.caseInsensitiveCompare(name) == .orderedSame
+            })
+                ?? snapshot.sources.first(where: {
+                    $0.name.lowercased().contains(name.lowercased())
+                })
+        else {
+            throw IntentError.sourceNotFound(name)
+        }
+        return .result(
+            value: source.indicator,
+            dialog: "\(source.name): \(source.description)"
+        )
+    }
+}
+
+// MARK: - Refresh
+
+struct RefreshSourcesIntent: AppIntent {
+    static let title: LocalizedStringResource = "Refresh Sources"
+    static let description = IntentDescription("Refresh all monitored status pages now.")
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        // The intent runs in the app process; the service appears shortly
+        // after a cold launch.
+        for _ in 0..<30 where AppRuntime.service == nil {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        guard let service = AppRuntime.service else {
+            throw IntentError.appNotRunning
+        }
+        await service.refreshAll()
+        let issues = await MainActor.run { service.issueCount }
+        let dialog: IntentDialog =
+            issues == 0
+            ? "Refreshed — all systems operational."
+            : "Refreshed — \(issues) source\(issues == 1 ? "" : "s") with issues."
+        return .result(dialog: dialog)
+    }
+}
+
+// MARK: - Errors
+
+enum IntentError: Error, CustomLocalizedStringResourceConvertible {
+    case noData
+    case sourceNotFound(String)
+    case appNotRunning
+
+    var localizedStringResource: LocalizedStringResource {
+        switch self {
+        case .noData:
+            return "No status data yet — launch StatusBar once."
+        case .sourceNotFound(let name):
+            return "No source matching “\(name)”."
+        case .appNotRunning:
+            return "StatusBar isn't running."
+        }
+    }
+}
+
+// MARK: - App Shortcuts (Spotlight phrases)
+
+struct StatusBarShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: GetWorstStatusIntent(),
+            phrases: [
+                "Get status in \(.applicationName)",
+                "Is anything down in \(.applicationName)",
+            ],
+            shortTitle: "Worst Status",
+            systemImageName: "checkmark.circle"
+        )
+        AppShortcut(
+            intent: RefreshSourcesIntent(),
+            phrases: ["Refresh \(.applicationName)"],
+            shortTitle: "Refresh",
+            systemImageName: "arrow.clockwise"
+        )
+    }
+}

--- a/Sources/StatusBarApp.swift
+++ b/Sources/StatusBarApp.swift
@@ -101,7 +101,10 @@ struct MiniTickIcon: View {
 
 class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     var service: StatusService? {
-        didSet { ScriptBridge.service = service }
+        didSet {
+            ScriptBridge.service = service
+            AppRuntime.service = service
+        }
     }
     var updateChecker: UpdateChecker?
     private var statusItem: NSStatusItem?

--- a/Sources/StatusCache.swift
+++ b/Sources/StatusCache.swift
@@ -1,0 +1,94 @@
+// StatusCache.swift
+// Machine-readable status snapshot written on every refresh.
+// Terminal tools (the statusbar CLI, prompt segments, SketchyBar, tmux)
+// read this file instead of talking to the app.
+
+import Foundation
+
+// MARK: - Cache Model
+
+struct StatusCacheSource: Codable, Equatable {
+    let name: String
+    let url: String
+    let indicator: String
+    let description: String
+    let group: String?
+    let snoozed: Bool
+}
+
+struct StatusCacheSnapshot: Codable, Equatable {
+    let updatedAt: String
+    let worst: String
+    let issueCount: Int
+    let sources: [StatusCacheSource]
+
+    static let version = 1
+}
+
+// MARK: - Cache Writer / Reader
+
+struct StatusCache {
+    /// Default location: `~/.cache/statusbar/status.json` — the terminal-tool
+    /// convention, stable for prompt integrations.
+    static var defaultURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".cache")
+            .appendingPathComponent("statusbar")
+            .appendingPathComponent("status.json")
+    }
+
+    let fileURL: URL
+
+    init(fileURL: URL = StatusCache.defaultURL) {
+        self.fileURL = fileURL
+    }
+
+    func write(_ snapshot: StatusCacheSnapshot) {
+        let fm = FileManager.default
+        let dir = fileURL.deletingLastPathComponent()
+        do {
+            if !fm.fileExists(atPath: dir.path) {
+                try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+            }
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(snapshot)
+            // Atomic: write to a temp file, then rename over the target
+            let tempURL = dir.appendingPathComponent(UUID().uuidString + ".tmp")
+            try data.write(to: tempURL)
+            _ = try fm.replaceItemAt(fileURL, withItemAt: tempURL)
+        } catch {
+            #if DEBUG
+                print("StatusCache: failed to write: \(error)")
+            #endif
+        }
+    }
+
+    func read() -> StatusCacheSnapshot? {
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        return try? JSONDecoder().decode(StatusCacheSnapshot.self, from: data)
+    }
+
+    static func snapshot(sources: [StatusSource], states: [UUID: SourceState]) -> StatusCacheSnapshot {
+        let cacheSources = sources.map { source -> StatusCacheSource in
+            let state = states[source.id] ?? SourceState()
+            return StatusCacheSource(
+                name: source.name,
+                url: source.baseURL,
+                indicator: state.indicator,
+                description: state.statusDescription,
+                group: source.group,
+                snoozed: source.isSnoozed
+            )
+        }
+        let worst =
+            states.values.max(by: { $0.indicatorSeverity < $1.indicatorSeverity })?.indicator ?? "unknown"
+        let issues = states.values.filter { $0.indicator != "none" && $0.indicator != "unknown" }.count
+        return StatusCacheSnapshot(
+            updatedAt: isoFormatterNoFrac.string(from: Date()),
+            worst: worst,
+            issueCount: issues,
+            sources: cacheSources
+        )
+    }
+}

--- a/Sources/StatusService.swift
+++ b/Sources/StatusService.swift
@@ -3,6 +3,13 @@
 
 import SwiftUI
 
+// MARK: - App Runtime Hook
+
+/// Static access to the live service for App Intents (mirrors ScriptBridge).
+enum AppRuntime {
+    nonisolated(unsafe) static var service: StatusService?
+}
+
 // MARK: - Status Service
 
 @MainActor
@@ -19,6 +26,7 @@ final class StatusService: ObservableObject {
     private var providerCache: [UUID: StatusProvider] = [:]
 
     let historyStore = HistoryStore()
+    private let statusCache = StatusCache()
     @AppStorage("statusHistory") private var storedHistory: String = "{}"
 
     let session: URLSession = {
@@ -73,6 +81,12 @@ final class StatusService: ObservableObject {
 
     private func persistSources() {
         storedSourcesJSON = StatusSource.encodeToJSON(sources)
+        writeCache()
+    }
+
+    /// Publish the machine-readable snapshot for the CLI and prompt tools.
+    private func writeCache() {
+        statusCache.write(StatusCache.snapshot(sources: sources, states: states))
     }
 
     // MARK: - Aggregate Status
@@ -190,6 +204,7 @@ final class StatusService: ObservableObject {
         }
 
         states[source.id]?.isLoading = false
+        writeCache()
     }
 
     private func notifyIfNeeded(

--- a/Tests/StatusCacheTests.swift
+++ b/Tests/StatusCacheTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import XCTest
+
+// MARK: - StatusCacheTests
+
+final class StatusCacheTests: XCTestCase {
+
+    private func tempCacheURL() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("statusbar-cache-tests-\(UUID().uuidString)")
+            .appendingPathComponent("status.json")
+    }
+
+    @MainActor
+    func testSnapshotFromSourcesAndStates() {
+        let ok = StatusSource(name: "GitHub", baseURL: "https://www.githubstatus.com")
+        let bad = StatusSource(
+            name: "Cloudflare", baseURL: "https://www.cloudflarestatus.com", group: "Cloud",
+            snoozedUntil: Date().addingTimeInterval(3600)
+        )
+        var okState = SourceState()
+        okState.summary = SPSummary(
+            page: SPPage(id: "p", name: "GitHub", url: "u", updatedAt: "", timeZone: nil),
+            status: SPStatus(indicator: "none", description: "All Systems Operational"),
+            components: [], incidents: []
+        )
+        var badState = SourceState()
+        badState.summary = SPSummary(
+            page: SPPage(id: "p2", name: "Cloudflare", url: "u2", updatedAt: "", timeZone: nil),
+            status: SPStatus(indicator: "minor", description: "Minor Service Outage"),
+            components: [], incidents: []
+        )
+
+        let snapshot = StatusCache.snapshot(
+            sources: [ok, bad],
+            states: [ok.id: okState, bad.id: badState]
+        )
+
+        XCTAssertEqual(snapshot.worst, "minor")
+        XCTAssertEqual(snapshot.issueCount, 1)
+        XCTAssertEqual(snapshot.sources.count, 2)
+        XCTAssertEqual(snapshot.sources[0].name, "GitHub")
+        XCTAssertEqual(snapshot.sources[0].indicator, "none")
+        XCTAssertEqual(snapshot.sources[1].indicator, "minor")
+        XCTAssertEqual(snapshot.sources[1].group, "Cloud")
+        XCTAssertTrue(snapshot.sources[1].snoozed)
+        XCTAssertFalse(snapshot.updatedAt.isEmpty)
+    }
+
+    @MainActor
+    func testSnapshotWithNoStatesIsUnknown() {
+        let source = StatusSource(name: "S", baseURL: "https://s.com")
+        let snapshot = StatusCache.snapshot(sources: [source], states: [:])
+        XCTAssertEqual(snapshot.worst, "unknown")
+        XCTAssertEqual(snapshot.issueCount, 0)
+        XCTAssertEqual(snapshot.sources[0].indicator, "unknown")
+    }
+
+    func testWriteAndReadRoundTrip() {
+        let url = tempCacheURL()
+        let cache = StatusCache(fileURL: url)
+        let snapshot = StatusCacheSnapshot(
+            updatedAt: "2026-07-20T21:00:00Z",
+            worst: "none",
+            issueCount: 0,
+            sources: [
+                StatusCacheSource(
+                    name: "GitHub", url: "https://www.githubstatus.com",
+                    indicator: "none", description: "All Systems Operational",
+                    group: nil, snoozed: false
+                )
+            ]
+        )
+        cache.write(snapshot)
+        let read = cache.read()
+        XCTAssertEqual(read, snapshot)
+        try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+    }
+
+    func testReadMissingFileReturnsNil() {
+        XCTAssertNil(StatusCache(fileURL: tempCacheURL()).read())
+    }
+
+    func testOverwriteReplacesPreviousSnapshot() {
+        let url = tempCacheURL()
+        let cache = StatusCache(fileURL: url)
+        let first = StatusCacheSnapshot(updatedAt: "a", worst: "none", issueCount: 0, sources: [])
+        let second = StatusCacheSnapshot(updatedAt: "b", worst: "major", issueCount: 2, sources: [])
+        cache.write(first)
+        cache.write(second)
+        XCTAssertEqual(cache.read(), second)
+        try? FileManager.default.removeItem(at: url.deletingLastPathComponent())
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -59,6 +59,12 @@ rm -rf "${BUILD_DIR}"
 mkdir -p "${MACOS}"
 mkdir -p "${RESOURCES}"
 
+# Protocol list for Swift const-value extraction (App Intents discovery)
+CONST_PROTOCOLS="${BUILD_DIR}/const_protocols.json"
+cat > "${CONST_PROTOCOLS}" <<'PROTOEOF'
+["AppIntent","EntityQuery","AppEntity","TransientAppEntity","AppEnum","AppShortcutsProvider","DynamicOptionsProvider","EntityPropertyQuery","EnumerableEntityQuery","EntityStringQuery","IntentParameterDependency","AnyResolverProviding","Resolvers","ControlValueProvider","AppIntentsPackage"]
+PROTOEOF
+
 SWIFT_FLAGS=(
     Sources/*.swift
     -parse-as-library
@@ -67,6 +73,10 @@ SWIFT_FLAGS=(
     -framework UserNotifications
     -framework Carbon
     -O
+    -whole-module-optimization
+    -module-name StatusBar
+    -Xfrontend -const-gather-protocols-file -Xfrontend "${CONST_PROTOCOLS}"
+    -emit-const-values
 )
 
 # Sparkle auto-update framework (optional)
@@ -106,6 +116,10 @@ else
         -target arm64-apple-macosx26.0 \
         -o "${MACOS}/${APP_NAME}"
 fi
+
+# Const-values are emitted beside the binary; stash them for the
+# App Intents metadata step (a stray file in MacOS/ breaks codesign)
+[ -f "${MACOS}/StatusBar.swiftconstvalues" ] && mv "${MACOS}/StatusBar.swiftconstvalues" "${BUILD_DIR}/StatusBar.swiftconstvalues"
 
 # Build the statusbar CLI (bundled as statusbar-cli; APFS is
 # case-insensitive, so it must not collide with the StatusBar app binary)
@@ -162,6 +176,29 @@ done
 
 # Copy scripting definition for AppleScript support
 [ -f "StatusBar.sdef" ] && cp StatusBar.sdef "${RESOURCES}/"
+
+# Extract App Intents metadata so Shortcuts/Spotlight can discover intents
+if [ -f "${BUILD_DIR}/StatusBar.swiftconstvalues" ] && xcrun --find appintentsmetadataprocessor > /dev/null 2>&1; then
+    echo "🎛  Extracting App Intents metadata..."
+    ls Sources/*.swift > "${BUILD_DIR}/appintents-sources.list"
+    echo "${BUILD_DIR}/StatusBar.swiftconstvalues" > "${BUILD_DIR}/appintents-constvals.list"
+    XCODE_BUILD_VERSION=$(xcodebuild -version 2>/dev/null | awk '/Build version/{print $3}')
+    xcrun appintentsmetadataprocessor \
+        --output "${RESOURCES}" \
+        --toolchain-dir "$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain" \
+        --module-name StatusBar \
+        --sdk-root "$(xcrun --show-sdk-path)" \
+        --xcode-version "${XCODE_BUILD_VERSION:-17A400}" \
+        --platform-family macOS \
+        --deployment-target 26.0 \
+        --target-triple arm64-apple-macosx26.0 \
+        --source-file-list "${BUILD_DIR}/appintents-sources.list" \
+        --swift-const-vals-list "${BUILD_DIR}/appintents-constvals.list" \
+        --binary-file "${MACOS}/${APP_NAME}" \
+        --force --quiet-warnings > /dev/null 2>&1 \
+        && echo "  Metadata.appintents written" \
+        || echo "  ⚠️  App Intents metadata extraction failed (intents won't appear in Shortcuts)"
+fi
 
 # Copy Sparkle.framework into the app bundle if enabled
 if [ "$SPARKLE" = true ] && [ -d "Vendor/Sparkle.framework" ]; then

--- a/build.sh
+++ b/build.sh
@@ -107,6 +107,31 @@ else
         -o "${MACOS}/${APP_NAME}"
 fi
 
+# Build the statusbar CLI (bundled as statusbar-cli; APFS is
+# case-insensitive, so it must not collide with the StatusBar app binary)
+CLI_SOURCES=(
+    cli/main.swift
+    cli/CLIFetcher.swift
+    Sources/Models.swift
+    Sources/ProviderMappings.swift
+    Sources/Helpers.swift
+    Sources/Constants.swift
+    Sources/StatusCache.swift
+)
+echo "🔧 Building statusbar CLI..."
+if [ "$RELEASE" = true ]; then
+    swiftc -O -parse-as-library "${CLI_SOURCES[@]}" \
+        -target arm64-apple-macosx26.0 -o "${BUILD_DIR}/cli-arm64"
+    swiftc -O -parse-as-library "${CLI_SOURCES[@]}" \
+        -target x86_64-apple-macosx26.0 -o "${BUILD_DIR}/cli-x86_64"
+    lipo -create "${BUILD_DIR}/cli-arm64" "${BUILD_DIR}/cli-x86_64" \
+        -output "${MACOS}/statusbar-cli"
+    rm "${BUILD_DIR}/cli-arm64" "${BUILD_DIR}/cli-x86_64"
+else
+    swiftc -O -parse-as-library "${CLI_SOURCES[@]}" \
+        -target arm64-apple-macosx26.0 -o "${MACOS}/statusbar-cli"
+fi
+
 # Copy Info.plist
 cp Info.plist "${CONTENTS}/Info.plist"
 
@@ -154,10 +179,13 @@ if [ -n "${CODESIGN_IDENTITY:-}" ]; then
             "${CONTENTS}/Frameworks/Sparkle.framework"
     fi
 
+    codesign --force --sign "$CODESIGN_IDENTITY" --options runtime --timestamp \
+        "${MACOS}/statusbar-cli"
     codesign --force --sign "$CODESIGN_IDENTITY" --options runtime \
         --entitlements StatusBar.entitlements --timestamp "${APP_BUNDLE}"
 else
     # Ad-hoc signing (local development)
+    codesign --force --sign - --options runtime "${MACOS}/statusbar-cli"
     codesign --force --sign - --options runtime --entitlements StatusBar.entitlements "${APP_BUNDLE}"
 fi
 

--- a/cli/CLIFetcher.swift
+++ b/cli/CLIFetcher.swift
@@ -1,0 +1,52 @@
+// CLIFetcher.swift
+// One-shot provider fetches for the CLI — works even when the app isn't
+// running. Reuses the app's models and pure mappings.
+
+import Foundation
+
+struct CLIFetcher {
+    let session: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 15
+        config.timeoutIntervalForResource = 30
+        return URLSession(configuration: config)
+    }()
+
+    func fetch(_ urlString: String) async throws -> Data {
+        guard let url = URL(string: urlString) else { throw FetchError.invalidURL }
+        let (data, response) = try await session.data(from: url)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            throw FetchError.httpStatus(http.statusCode)
+        }
+        return data
+    }
+
+    /// Detects the provider and returns the live status for a base URL.
+    func liveStatus(baseURL: String) async -> (indicator: String, description: String) {
+        // Atlassian / incident.io-compat / Instatus all serve /api/v2/summary.json
+        if let data = try? await fetch("\(baseURL)/api/v2/summary.json") {
+            if let summary = try? JSONDecoder().decode(SPSummary.self, from: data) {
+                return (summary.status.indicator, summary.status.description)
+            }
+            if let instatus = try? JSONDecoder().decode(InstatusSummary.self, from: data) {
+                let summary = SPSummary.fromInstatus(instatus, components: [], baseURL: baseURL)
+                return (summary.status.indicator, summary.status.description)
+            }
+        }
+        // Gatus
+        if let data = try? await fetch("\(baseURL)/api/v1/endpoints/statuses?page=1&pageSize=100"),
+            let endpoints = try? JSONDecoder().decode([GatusEndpointStatus].self, from: data)
+        {
+            let summary = SPSummary.fromGatus(endpoints, baseURL: baseURL)
+            return (summary.status.indicator, summary.status.description)
+        }
+        // incident.io widget fallback
+        if let data = try? await fetch("\(baseURL)/proxy/widget"),
+            let widget = try? JSONDecoder().decode(IIOWidgetResponse.self, from: data)
+        {
+            let (summary, _) = SPSummary.fromIncidentIOWidget(widget, baseURL: baseURL)
+            return (summary.status.indicator, summary.status.description)
+        }
+        return ("unknown", "Unreachable")
+    }
+}

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -65,6 +65,55 @@ func openURLScheme(_ url: String) {
     process.waitUntilExit()
 }
 
+// MARK: - Repo config (.statusbar)
+
+/// Walks up from the working directory looking for a `.statusbar` file:
+/// one source name per line, `#` comments. Scopes status/prompt output to
+/// that project's upstream dependencies.
+func repoConfig() -> (names: [String], path: String)? {
+    var dir = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+    while true {
+        let file = dir.appendingPathComponent(".statusbar")
+        if let text = try? String(contentsOf: file, encoding: .utf8) {
+            let names = text.split(separator: "\n")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+            if !names.isEmpty { return (names, file.path) }
+        }
+        if dir.path == "/" { return nil }
+        dir.deleteLastPathComponent()
+    }
+}
+
+struct ScopedSnapshot {
+    let sources: [StatusCacheSource]
+    let missing: [String]
+    let configPath: String
+    var worst: String {
+        let ranked = sources.map { severityRank($0.indicator) }.max() ?? -1
+        return ranked <= 0 ? (ranked == 0 ? "none" : "unknown") : ["none", "minor", "major", "critical"][ranked]
+    }
+    var issueCount: Int {
+        sources.filter { $0.indicator != "none" && $0.indicator != "unknown" }.count
+    }
+}
+
+func applyRepoScope(_ snapshot: StatusCacheSnapshot) -> ScopedSnapshot? {
+    guard let config = repoConfig() else { return nil }
+    var matched: [StatusCacheSource] = []
+    var missing: [String] = []
+    for name in config.names {
+        if let source = findSource(name, in: snapshot),
+            !matched.contains(where: { $0.name == source.name })
+        {
+            matched.append(source)
+        } else {
+            missing.append(name)
+        }
+    }
+    return ScopedSnapshot(sources: matched, missing: missing, configPath: config.path)
+}
+
 func severityRank(_ indicator: String) -> Int {
     ["none": 0, "minor": 1, "major": 2, "critical": 3][indicator] ?? -1
 }
@@ -77,7 +126,7 @@ func printStatusLine(name: String, indicator: String, description: String, snooz
     print("\(glyph(for: indicator)) \(pad) \(paint(description, "90"))\(snooze)")
 }
 
-func cmdStatus(name: String?, json: Bool, fresh: Bool) async {
+func cmdStatus(name: String?, json: Bool, fresh: Bool, allFlag: Bool) async {
     guard let snapshot = loadCache() else { return }
 
     if let name {
@@ -102,6 +151,34 @@ func cmdStatus(name: String?, json: Bool, fresh: Bool) async {
                 description: description, snoozed: source.snoozed)
         }
         exit(indicator == "none" ? 0 : (severityRank(indicator) > 0 ? 1 : 2))
+    }
+
+    // Repo scope: a .statusbar file narrows output to that project's deps
+    if !allFlag, let scoped = applyRepoScope(snapshot) {
+        if json {
+            let payload: [String: Any] = [
+                "worst": scoped.worst,
+                "issueCount": scoped.issueCount,
+                "scope": scoped.configPath,
+                "sources": scoped.sources.map {
+                    ["name": $0.name, "indicator": $0.indicator, "description": $0.description]
+                },
+                "missing": scoped.missing,
+            ]
+            let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+            print(String(data: data ?? Data(), encoding: .utf8) ?? "{}")
+        } else {
+            for source in scoped.sources {
+                printStatusLine(
+                    name: source.name, indicator: source.indicator,
+                    description: source.description, snoozed: source.snoozed)
+            }
+            for name in scoped.missing {
+                print("\(glyph(for: "unknown")) \(name.padding(toLength: max(name.count, 18), withPad: " ", startingAt: 0)) \(paint("not monitored — statusbar add <url> \(name)", "90"))")
+            }
+            print(paint("— scoped by \(scoped.configPath)", "90"))
+        }
+        exit(scoped.worst == "none" ? 0 : (severityRank(scoped.worst) > 0 ? 1 : 2))
     }
 
     // All sources
@@ -140,15 +217,21 @@ func cmdStatus(name: String?, json: Bool, fresh: Bool) async {
     exit(worst == "none" ? 0 : (severityRank(worst) > 0 ? 1 : 2))
 }
 
-func cmdPrompt() {
+func cmdPrompt(allFlag: Bool) {
     guard let snapshot = loadCache(required: false) else {
         print("○")
         exit(0)
     }
-    if snapshot.issueCount > 0 {
-        print("\(plainGlyph(for: snapshot.worst))\(snapshot.issueCount)")
+    var worst = snapshot.worst
+    var issues = snapshot.issueCount
+    if !allFlag, let scoped = applyRepoScope(snapshot), !scoped.sources.isEmpty {
+        worst = scoped.worst
+        issues = scoped.issueCount
+    }
+    if issues > 0 {
+        print("\(plainGlyph(for: worst))\(issues)")
     } else {
-        print(plainGlyph(for: snapshot.worst))
+        print(plainGlyph(for: worst))
     }
     exit(0)
 }
@@ -193,12 +276,16 @@ let helpText = """
 
     OPTIONS
       --json            Machine-readable output (status)
+      --all             Ignore a .statusbar repo scope
       --fresh           Fetch live from providers instead of the cache (status)
       --timeout <sec>   wait: give up after N seconds (default 1800)
       --interval <sec>  wait: poll every N seconds (default 30)
 
     The cache at ~/.cache/statusbar/status.json is refreshed by the app on
     every poll; `status` reads it instantly with no network.
+
+    Drop a `.statusbar` file in a repo (one source name per line, # for
+    comments) and `status`/`prompt` scope to that project's dependencies.
     """
 
 // MARK: - Entry
@@ -215,6 +302,7 @@ struct StatusBarCLI {
 
         let json = args.contains("--json")
         let fresh = args.contains("--fresh")
+        let allFlag = args.contains("--all")
         func optionValue(_ flag: String) -> String? {
             guard let idx = args.firstIndex(of: flag), idx + 1 < args.count else { return nil }
             return args[idx + 1]
@@ -223,9 +311,9 @@ struct StatusBarCLI {
 
         switch command {
         case "status", "list":
-            await cmdStatus(name: positional.first, json: json, fresh: fresh)
+            await cmdStatus(name: positional.first, json: json, fresh: fresh, allFlag: allFlag)
         case "prompt":
-            cmdPrompt()
+            cmdPrompt(allFlag: allFlag)
         case "wait":
             guard let name = positional.first else { fail("usage: statusbar wait <name>") }
             let timeout = TimeInterval(optionValue("--timeout") ?? "") ?? 1800

--- a/cli/main.swift
+++ b/cli/main.swift
@@ -1,0 +1,271 @@
+// main.swift — the statusbar CLI
+// Reads the app's status cache (~/.cache/statusbar/status.json), can fetch
+// live from providers when the app isn't running, and drives the app via
+// its statusbar:// URL scheme.
+
+import Foundation
+
+// MARK: - Output helpers
+
+let stdoutIsTTY = isatty(fileno(stdout)) == 1
+let colorEnabled = stdoutIsTTY && ProcessInfo.processInfo.environment["NO_COLOR"] == nil
+
+func paint(_ text: String, _ code: String) -> String {
+    colorEnabled ? "\u{001B}[\(code)m\(text)\u{001B}[0m" : text
+}
+
+func glyph(for indicator: String) -> String {
+    switch indicator {
+    case "none": return paint("●", "32")
+    case "minor": return paint("▲", "33")
+    case "major": return paint("▲", "38;5;208")
+    case "critical": return paint("✖", "31")
+    default: return paint("○", "90")
+    }
+}
+
+func plainGlyph(for indicator: String) -> String {
+    switch indicator {
+    case "none": return "●"
+    case "minor", "major": return "▲"
+    case "critical": return "✖"
+    default: return "○"
+    }
+}
+
+func fail(_ message: String, code: Int32 = 64) -> Never {
+    FileHandle.standardError.write(Data(("statusbar: " + message + "\n").utf8))
+    exit(code)
+}
+
+// MARK: - Cache access
+
+func loadCache(required: Bool = true) -> StatusCacheSnapshot? {
+    if let snapshot = StatusCache().read() { return snapshot }
+    if required {
+        fail(
+            "no status cache at \(StatusCache.defaultURL.path).\n"
+                + "Launch StatusBar.app once, or use --fresh to fetch live.", code: 2)
+    }
+    return nil
+}
+
+func findSource(_ name: String, in snapshot: StatusCacheSnapshot) -> StatusCacheSource? {
+    snapshot.sources.first { $0.name.caseInsensitiveCompare(name) == .orderedSame }
+        ?? snapshot.sources.first { $0.name.lowercased().contains(name.lowercased()) }
+}
+
+// MARK: - URL scheme passthrough
+
+func openURLScheme(_ url: String) {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+    process.arguments = ["-g", url]
+    try? process.run()
+    process.waitUntilExit()
+}
+
+func severityRank(_ indicator: String) -> Int {
+    ["none": 0, "minor": 1, "major": 2, "critical": 3][indicator] ?? -1
+}
+
+// MARK: - Commands
+
+func printStatusLine(name: String, indicator: String, description: String, snoozed: Bool) {
+    let pad = name.padding(toLength: max(name.count, 18), withPad: " ", startingAt: 0)
+    let snooze = snoozed ? paint(" (snoozed)", "90") : ""
+    print("\(glyph(for: indicator)) \(pad) \(paint(description, "90"))\(snooze)")
+}
+
+func cmdStatus(name: String?, json: Bool, fresh: Bool) async {
+    guard let snapshot = loadCache() else { return }
+
+    if let name {
+        guard let source = findSource(name, in: snapshot) else {
+            fail("no source matching \u{201C}\(name)\u{201D}", code: 2)
+        }
+        var indicator = source.indicator
+        var description = source.description
+        if fresh {
+            (indicator, description) = await CLIFetcher().liveStatus(baseURL: source.url)
+        }
+        if json {
+            let payload: [String: Any] = [
+                "name": source.name, "url": source.url,
+                "indicator": indicator, "description": description,
+            ]
+            let data = try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+            print(String(data: data ?? Data(), encoding: .utf8) ?? "{}")
+        } else {
+            printStatusLine(
+                name: source.name, indicator: indicator,
+                description: description, snoozed: source.snoozed)
+        }
+        exit(indicator == "none" ? 0 : (severityRank(indicator) > 0 ? 1 : 2))
+    }
+
+    // All sources
+    var worst = snapshot.worst
+    if fresh {
+        let fetcher = CLIFetcher()
+        var rank = 0
+        for source in snapshot.sources {
+            let (indicator, description) = await fetcher.liveStatus(baseURL: source.url)
+            rank = max(rank, severityRank(indicator))
+            if !json {
+                printStatusLine(
+                    name: source.name, indicator: indicator,
+                    description: description, snoozed: source.snoozed)
+            }
+        }
+        worst = ["none", "minor", "major", "critical"][max(rank, 0)]
+        exit(worst == "none" ? 0 : 1)
+    }
+
+    if json {
+        let data = try? JSONEncoder().encode(snapshot)
+        print(String(data: data ?? Data(), encoding: .utf8) ?? "{}")
+    } else {
+        for source in snapshot.sources {
+            printStatusLine(
+                name: source.name, indicator: source.indicator,
+                description: source.description, snoozed: source.snoozed)
+        }
+        let summary =
+            snapshot.issueCount == 0
+            ? "all systems operational"
+            : "\(snapshot.issueCount) source\(snapshot.issueCount == 1 ? "" : "s") with issues"
+        print(paint("— \(summary) · updated \(snapshot.updatedAt)", "90"))
+    }
+    exit(worst == "none" ? 0 : (severityRank(worst) > 0 ? 1 : 2))
+}
+
+func cmdPrompt() {
+    guard let snapshot = loadCache(required: false) else {
+        print("○")
+        exit(0)
+    }
+    if snapshot.issueCount > 0 {
+        print("\(plainGlyph(for: snapshot.worst))\(snapshot.issueCount)")
+    } else {
+        print(plainGlyph(for: snapshot.worst))
+    }
+    exit(0)
+}
+
+func cmdWait(name: String, timeout: TimeInterval, interval: TimeInterval) async {
+    guard let snapshot = loadCache() else { return }
+    guard let source = findSource(name, in: snapshot) else {
+        fail("no source matching \u{201C}\(name)\u{201D}", code: 2)
+    }
+    let fetcher = CLIFetcher()
+    let deadline = Date().addingTimeInterval(timeout)
+    while true {
+        let (indicator, description) = await fetcher.liveStatus(baseURL: source.url)
+        if indicator == "none" {
+            print("\(glyph(for: "none")) \(source.name) is operational")
+            exit(0)
+        }
+        print("\(glyph(for: indicator)) \(source.name): \(description) — retrying in \(Int(interval))s")
+        if Date() >= deadline {
+            fail("timed out after \(Int(timeout))s waiting for \(source.name)", code: 1)
+        }
+        try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+    }
+}
+
+let helpText = """
+    statusbar — every status page you care about, from the terminal
+
+    USAGE
+      statusbar <command> [options]
+
+    COMMANDS
+      status [name]     Current status for all sources or one (exit 0 ok, 1 issues)
+      list              Alias for status
+      wait <name>       Block until a source is operational again (live polling)
+      prompt            Compact glyph for shell prompts (e.g. "●" or "▲1")
+      refresh           Ask the running app to refresh now
+      open [name]       Open the popover, optionally at a source
+      add <url> [name]  Add a source through the app
+      remove <name>     Remove a source through the app
+      cache-path        Print the status cache location
+
+    OPTIONS
+      --json            Machine-readable output (status)
+      --fresh           Fetch live from providers instead of the cache (status)
+      --timeout <sec>   wait: give up after N seconds (default 1800)
+      --interval <sec>  wait: poll every N seconds (default 30)
+
+    The cache at ~/.cache/statusbar/status.json is refreshed by the app on
+    every poll; `status` reads it instantly with no network.
+    """
+
+// MARK: - Entry
+
+@main
+struct StatusBarCLI {
+    static func main() async {
+        var args = Array(CommandLine.arguments.dropFirst())
+        guard let command = args.first else {
+            print(helpText)
+            exit(64)
+        }
+        args.removeFirst()
+
+        let json = args.contains("--json")
+        let fresh = args.contains("--fresh")
+        func optionValue(_ flag: String) -> String? {
+            guard let idx = args.firstIndex(of: flag), idx + 1 < args.count else { return nil }
+            return args[idx + 1]
+        }
+        let positional = args.filter { !$0.hasPrefix("--") && $0 != optionValue("--timeout") && $0 != optionValue("--interval") }
+
+        switch command {
+        case "status", "list":
+            await cmdStatus(name: positional.first, json: json, fresh: fresh)
+        case "prompt":
+            cmdPrompt()
+        case "wait":
+            guard let name = positional.first else { fail("usage: statusbar wait <name>") }
+            let timeout = TimeInterval(optionValue("--timeout") ?? "") ?? 1800
+            let interval = TimeInterval(optionValue("--interval") ?? "") ?? 30
+            await cmdWait(name: name, timeout: max(timeout, 1), interval: max(interval, 5))
+        case "refresh":
+            openURLScheme("statusbar://refresh")
+            print("refresh requested")
+        case "open":
+            if let name = positional.first,
+                let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+            {
+                openURLScheme("statusbar://open?source=\(encoded)")
+            } else {
+                openURLScheme("statusbar://open")
+            }
+        case "add":
+            guard let url = positional.first,
+                let encodedURL = url.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+            else { fail("usage: statusbar add <url> [name]") }
+            var scheme = "statusbar://add?url=\(encodedURL)"
+            if positional.count > 1,
+                let encodedName = positional[1].addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+            {
+                scheme += "&name=\(encodedName)"
+            }
+            openURLScheme(scheme)
+            print("add requested")
+        case "remove":
+            guard let name = positional.first,
+                let encoded = name.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+            else { fail("usage: statusbar remove <name>") }
+            openURLScheme("statusbar://remove?name=\(encoded)")
+            print("remove requested")
+        case "cache-path":
+            print(StatusCache.defaultURL.path)
+        case "help", "--help", "-h":
+            print(helpText)
+        default:
+            fail("unknown command \u{201C}\(command)\u{201D} — see `statusbar help`")
+        }
+    }
+}

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -319,6 +319,14 @@ statusbar wait npm &amp;&amp; npm publish   # block until recovery
 statusbar prompt            # "●" or "▲1" for prompts</code></pre>
             <button class="copy-btn" aria-label="Copy code">Copy</button>
           </div>
+          <p class="automate-desc">Drop a <code>.statusbar</code> file in a repo (one source name per line) and <code>status</code>/<code>prompt</code> scope to that project&rsquo;s upstream dependencies.</p>
+          <div class="code-block-wrapper">
+            <pre><code># .statusbar — upstream deps for this repo
+GitHub
+npm
+Vercel</code></pre>
+            <button class="copy-btn" aria-label="Copy code">Copy</button>
+          </div>
         </div>
 
         <div class="glass-card automate-card">

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -58,6 +58,7 @@
         <a href="#automate">script hooks</a>
         <a href="#automate">url scheme</a>
         <a href="#automate">applescript</a>
+        <a href="#terminal">cli &amp; prompt</a>
         <a href="#docs">source catalog</a>
       </nav>
     </div>
@@ -288,6 +289,98 @@ end tell</code></pre>
             </div>
           </div>
         </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="terminal">
+    <div class="container">
+      <p class="section-label">terminal</p>
+      <h2>The CLI and your prompt</h2>
+      <p class="section-sub">The app writes a status snapshot to <code>~/.cache/statusbar/status.json</code> on every refresh. The bundled CLI reads it instantly &mdash; and anything else on your Mac can too.</p>
+
+      <div class="automate-row">
+        <div class="glass-card automate-card">
+          <div class="automate-card-header">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
+            <h3>statusbar CLI</h3>
+          </div>
+          <p class="automate-desc">Bundled with the app. Link it once, then query, script, and wait on statuses from any shell.</p>
+          <div class="code-block-wrapper">
+            <pre><code>sudo ln -sf /Applications/StatusBar.app/Contents/MacOS/statusbar-cli \
+  /usr/local/bin/statusbar</code></pre>
+            <button class="copy-btn" aria-label="Copy code">Copy</button>
+          </div>
+          <div class="code-block-wrapper">
+            <pre><code>statusbar status            # all sources, colored, exit 0/1
+statusbar status github     # one source
+statusbar status --json     # machine-readable
+statusbar wait npm &amp;&amp; npm publish   # block until recovery
+statusbar prompt            # "●" or "▲1" for prompts</code></pre>
+            <button class="copy-btn" aria-label="Copy code">Copy</button>
+          </div>
+        </div>
+
+        <div class="glass-card automate-card">
+          <div class="automate-card-header">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><line x1="2" y1="9" x2="22" y2="9"/></svg>
+            <h3>Status in your prompt</h3>
+          </div>
+          <p class="automate-desc">One glyph in your status line: <code>&#9679;</code> when clear, <code>&#9650;1</code> when something's up.</p>
+          <div class="collapsible">
+            <button class="collapsible-trigger" id="starship-trigger">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><path d="M4 2l6 4-6 4z"/></svg>
+              Starship
+            </button>
+            <div class="collapsible-content" id="starship-content">
+              <div class="code-block-wrapper">
+                <pre><code># ~/.config/starship.toml
+[custom.statusbar]
+command = "statusbar prompt"
+when = true
+format = "[$output]($style) "
+style = "bold green"</code></pre>
+                <button class="copy-btn" aria-label="Copy code">Copy</button>
+              </div>
+            </div>
+          </div>
+          <div class="collapsible">
+            <button class="collapsible-trigger" id="tmux-trigger">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><path d="M4 2l6 4-6 4z"/></svg>
+              tmux
+            </button>
+            <div class="collapsible-content" id="tmux-content">
+              <div class="code-block-wrapper">
+                <pre><code># ~/.tmux.conf
+set -g status-right '#(statusbar prompt) %H:%M'
+set -g status-interval 60</code></pre>
+                <button class="copy-btn" aria-label="Copy code">Copy</button>
+              </div>
+            </div>
+          </div>
+          <div class="collapsible">
+            <button class="collapsible-trigger" id="sketchybar-trigger">
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor"><path d="M4 2l6 4-6 4z"/></svg>
+              SketchyBar
+            </button>
+            <div class="collapsible-content" id="sketchybar-content">
+              <div class="code-block-wrapper">
+                <pre><code># ~/.config/sketchybar/plugins/statusbar.sh
+#!/bin/bash
+sketchybar --set "$NAME" label="$(statusbar prompt)"</code></pre>
+                <button class="copy-btn" aria-label="Copy code">Copy</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="glass-card automate-card automate-card-wide">
+        <div class="automate-card-header">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+          <h3>Shortcuts &amp; Spotlight</h3>
+        </div>
+        <p class="automate-desc">StatusBar exposes App Intents: <strong>Get Worst Status</strong>, <strong>Get Source Status</strong>, and <strong>Refresh Sources</strong>. Wire them into Shortcuts automations, Focus modes, or just type &ldquo;status&rdquo; into Spotlight.</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

The approved automation-surface batch (widget follows in its own PR):

- **Status cache file** — the app writes `~/.cache/statusbar/status.json` (atomic, versioned) on every refresh and source mutation. This is the stable interface for all terminal tooling.
- **`statusbar` CLI**, bundled at `Contents/MacOS/statusbar-cli` (named to dodge the case-insensitive-APFS collision with the app binary — discovered the hard way when the first build overwrote the app with the CLI):
  - `status [name]` (cache-backed, `--json`, `--fresh` for live provider fetches, meaningful exit codes)
  - **`wait <name>`** — block until a source recovers: `statusbar wait npm && npm publish`
  - `prompt` — compact glyph (`●` / `▲1`) for shell prompts
  - `refresh` / `open` / `add` / `remove` via the URL scheme, `cache-path`
  - Colored TTY output, `NO_COLOR` respected; one-shot fetches reuse the app's pure provider mappings and work without the app running.
- **App Intents** — *Get Worst Status*, *Get Source Status*, *Refresh Sources* + App Shortcuts phrases for Shortcuts/Spotlight. Live service when running, cache fallback. Discovery metadata (`Metadata.appintents`) is extracted in build.sh via swiftc const-value emission + `appintentsmetadataprocessor` — the step Xcode normally does that a raw `swiftc` build must do by hand.
- **Docs**: a new "terminal" section on the docs page (CLI install + starship/tmux/SketchyBar snippets, Shortcuts card) and a matching README section; changelog updated.

## Verified

- `make check` green (203 tests, incl. new cache round-trip/snapshot tests); `make build` clean with metadata extraction
- CLI exercised end-to-end against real sources: colored status list, `--json`, `prompt`, `wait` (returns on operational), `--fresh` (correctly reports unreachable)
- Intents metadata confirmed to contain all three actions; full Shortcuts-app visibility check pending an /Applications install (dev-path builds don't index)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015b2b1TQZjDQnSsHCUpkFxC