### PR TITLE
chore: stamp changelog for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to StatusBar. Full release notes with downloads live on the
 [GitHub Releases page](https://github.com/alexnodeland/StatusBar/releases).
 
-## Unreleased
+## v0.4.0 — 2026-07-21
 
 - Status cache file at `~/.cache/statusbar/status.json`, refreshed on
   every poll — the interface for terminal tooling


### PR DESCRIPTION
Stamps the Unreleased section as **v0.4.0 — 2026-07-21**, matching the tag pushed today.

Release contents: status cache + bundled CLI (`status`/`wait`/`prompt`/`version`), per-repo `.statusbar` scoping, App Intents, desktop widget, one-click CLI install + Homebrew cask auto-link, and the website's live coded renders + CLI reference page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015b2b1TQZjDQnSsHCUpkFxC