### PR TITLE
feat(site): rework nav and docs discoverability

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -18,10 +18,11 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=3">
+  <link rel="stylesheet" href="style.css?v=4">
 </head>
 <body class="docs-page">
 
+  <!-- shared nav — keep in sync across index.html / docs.html / cli.html -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
       <a href="index.html" class="nav-brand">
@@ -37,10 +38,10 @@
       </button>
       <ul class="nav-links" id="nav-links">
         <li><a href="index.html#features">Features</a></li>
-        <li><a href="index.html#severity">Severity</a></li>
         <li><a href="index.html#install">Install</a></li>
         <li><a href="index.html#faq">FAQ</a></li>
-        <li><a href="docs.html" class="active">Docs</a></li>
+        <li><a href="docs.html">Docs</a></li>
+        <li><a href="cli.html" class="active" aria-current="page">CLI</a></li>
         <li><a href="https://github.com/alexnodeland/StatusBar">GitHub</a></li>
         <li><a class="nav-cta" href="https://github.com/alexnodeland/StatusBar/releases/latest">Download</a></li>
       </ul>
@@ -53,7 +54,10 @@
       <p class="section-label">reference</p>
       <h1><code>statusbar</code> CLI</h1>
       <p>Every status page you care about, from the terminal. The CLI ships inside StatusBar.app and reads the same live snapshot the app maintains &mdash; no network, no waiting.</p>
-      <nav class="toc-chips" aria-label="On this page">
+      <nav class="toc-chips" aria-label="Documentation">
+        <a href="docs.html" class="toc-chip-page">automate &amp; integrate</a>
+        <a href="cli.html" class="toc-chip-page" aria-current="page">cli reference</a>
+        <span class="toc-sep" aria-hidden="true"></span>
         <a href="#cli-install">install</a>
         <a href="#cli-commands">commands</a>
         <a href="#cli-options">options</a>
@@ -261,6 +265,8 @@ Vercel</code></pre>
   <footer class="footer">
     <div class="container">
       <nav class="footer-links">
+        <a href="docs.html">Docs</a>
+        <a href="cli.html">CLI</a>
         <a href="https://github.com/alexnodeland/StatusBar">GitHub</a>
         <a href="https://github.com/alexnodeland/StatusBar/releases/latest">Releases</a>
         <a href="https://github.com/alexnodeland/StatusBar/blob/main/CHANGELOG.md">Changelog</a>
@@ -272,6 +278,6 @@ Vercel</code></pre>
     </div>
   </footer>
 
-  <script src="script.js?v=2"></script>
+  <script src="script.js?v=3"></script>
 </body>
 </html>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -18,10 +18,11 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=3">
+  <link rel="stylesheet" href="style.css?v=4">
 </head>
 <body class="docs-page">
 
+  <!-- shared nav — keep in sync across index.html / docs.html / cli.html -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
       <a href="index.html" class="nav-brand">
@@ -37,10 +38,10 @@
       </button>
       <ul class="nav-links" id="nav-links">
         <li><a href="index.html#features">Features</a></li>
-        <li><a href="index.html#severity">Severity</a></li>
         <li><a href="index.html#install">Install</a></li>
         <li><a href="index.html#faq">FAQ</a></li>
-        <li><a href="docs.html" class="active">Docs</a></li>
+        <li><a href="docs.html" class="active" aria-current="page">Docs</a></li>
+        <li><a href="cli.html">CLI</a></li>
         <li><a href="https://github.com/alexnodeland/StatusBar">GitHub</a></li>
         <li><a class="nav-cta" href="https://github.com/alexnodeland/StatusBar/releases/latest">Download</a></li>
       </ul>
@@ -53,15 +54,17 @@
       <p class="section-label">docs</p>
       <h1>Automate &amp; integrate</h1>
       <p>Everything in StatusBar is scriptable. Push alerts where your team lives, run scripts on status events, and drive the app from anything that can open a URL.</p>
-      <nav class="toc-chips" aria-label="On this page">
-        <a href="#automate">webhooks</a>
-        <a href="#automate">script hooks</a>
-        <a href="#automate">url scheme</a>
-        <a href="#automate">applescript</a>
-        <a href="#terminal">cli &amp; prompt</a>
-        <a href="cli.html">cli reference</a>
+      <nav class="toc-chips" aria-label="Documentation">
+        <a href="docs.html" class="toc-chip-page" aria-current="page">automate &amp; integrate</a>
+        <a href="cli.html" class="toc-chip-page">cli reference</a>
+        <span class="toc-sep" aria-hidden="true"></span>
+        <a href="#webhooks">webhooks</a>
+        <a href="#hooks">script hooks</a>
+        <a href="#url-scheme">url scheme</a>
+        <a href="#applescript">applescript</a>
+        <a href="#terminal">setup guides</a>
         <a href="#widget">widget</a>
-        <a href="#docs">source catalog</a>
+        <a href="#catalog">source catalog</a>
       </nav>
     </div>
   </header>
@@ -74,7 +77,7 @@
       <!-- Top row: Webhooks + Script Hooks -->
       <div class="automate-row">
         <!-- Webhooks -->
-        <div class="glass-card automate-card">
+        <div class="glass-card automate-card" id="webhooks">
           <div class="automate-card-header">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
             <h3>Webhooks</h3>
@@ -111,7 +114,7 @@
         </div>
 
         <!-- Script Hooks -->
-        <div class="glass-card automate-card">
+        <div class="glass-card automate-card" id="hooks">
           <div class="automate-card-header">
             <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"/><line x1="12" y1="19" x2="20" y2="19"/></svg>
             <h3>Script Hooks</h3>
@@ -190,7 +193,7 @@ echo "[$(date)] $STATUSBAR_SOURCE_NAME: $STATUSBAR_TITLE" &gt;&gt; "$LOG"</code>
       </div>
 
       <!-- URL Scheme (full-width) -->
-      <div class="glass-card automate-card automate-card-wide">
+      <div class="glass-card automate-card automate-card-wide" id="url-scheme">
         <div class="automate-card-header">
           <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
           <h3>URL Scheme</h3>
@@ -243,7 +246,7 @@ echo "[$(date)] $STATUSBAR_SOURCE_NAME: $STATUSBAR_TITLE" &gt;&gt; "$LOG"</code>
       </div>
 
       <!-- AppleScript (full-width, two-column layout) -->
-      <div class="glass-card automate-card automate-card-wide">
+      <div class="glass-card automate-card automate-card-wide" id="applescript">
         <div class="applescript-layout">
           <div class="applescript-info">
             <div class="automate-card-header">
@@ -423,7 +426,7 @@ sketchybar --set "$NAME" label="$(statusbar prompt)"</code></pre>
     </div>
   </section>
 
-  <section id="docs">
+  <section id="catalog">
     <div class="container">
       <p class="section-label">catalog</p>
       <h2>Adding Sources</h2>
@@ -468,6 +471,8 @@ sketchybar --set "$NAME" label="$(statusbar prompt)"</code></pre>
   <footer class="footer">
     <div class="container">
       <nav class="footer-links">
+        <a href="docs.html">Docs</a>
+        <a href="cli.html">CLI</a>
         <a href="https://github.com/alexnodeland/StatusBar">GitHub</a>
         <a href="https://github.com/alexnodeland/StatusBar/releases/latest">Releases</a>
         <a href="https://github.com/alexnodeland/StatusBar/blob/main/CHANGELOG.md">Changelog</a>
@@ -479,6 +484,6 @@ sketchybar --set "$NAME" label="$(statusbar prompt)"</code></pre>
     </div>
   </footer>
 
-  <script src="script.js?v=2"></script>
+  <script src="script.js?v=3"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=3">
+  <link rel="stylesheet" href="style.css?v=4">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -38,6 +38,7 @@
 </head>
 <body>
 
+  <!-- shared nav — keep in sync across index.html / docs.html / cli.html -->
   <nav class="nav" id="nav">
     <div class="nav-inner">
       <a href="index.html" class="nav-brand">
@@ -52,11 +53,11 @@
         </svg>
       </button>
       <ul class="nav-links" id="nav-links">
-        <li><a href="index.html#features">Features</a></li>
-        <li><a href="index.html#severity">Severity</a></li>
-        <li><a href="index.html#install">Install</a></li>
-        <li><a href="index.html#faq">FAQ</a></li>
+        <li><a href="#features">Features</a></li>
+        <li><a href="#install">Install</a></li>
+        <li><a href="#faq">FAQ</a></li>
         <li><a href="docs.html">Docs</a></li>
+        <li><a href="cli.html">CLI</a></li>
         <li><a href="https://github.com/alexnodeland/StatusBar">GitHub</a></li>
         <li><a class="nav-cta" href="https://github.com/alexnodeland/StatusBar/releases/latest">Download</a></li>
       </ul>
@@ -296,6 +297,8 @@ brew install --cask statusbar</code></pre>
   <footer class="footer">
     <div class="container">
       <nav class="footer-links">
+        <a href="docs.html">Docs</a>
+        <a href="cli.html">CLI</a>
         <a href="https://github.com/alexnodeland/StatusBar">GitHub</a>
         <a href="https://github.com/alexnodeland/StatusBar/releases/latest">Releases</a>
         <a href="https://github.com/alexnodeland/StatusBar/blob/main/CHANGELOG.md">Changelog</a>
@@ -307,6 +310,6 @@ brew install --cask statusbar</code></pre>
     </div>
   </footer>
 
-  <script src="script.js?v=2"></script>
+  <script src="script.js?v=3"></script>
 </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -263,7 +263,8 @@ section {
 }
 
 .nav-links a:hover,
-.nav-links a.active {
+.nav-links a.active,
+.nav-links a[aria-current="page"] {
   color: var(--text-primary);
 }
 
@@ -1487,6 +1488,30 @@ section {
 .toc-chips a:hover {
   color: var(--text-primary);
   border-color: var(--text-tertiary);
+}
+
+/* Cross-page doc chips (Docs ↔ CLI) */
+.toc-chips .toc-chip-page {
+  color: var(--text-primary);
+  border-color: var(--text-tertiary);
+}
+
+.toc-chips .toc-chip-page[aria-current="page"] {
+  background: color-mix(in srgb, var(--accent) 12%, var(--surface));
+  border-color: var(--accent);
+}
+
+.toc-sep {
+  width: 1px;
+  height: 16px;
+  align-self: center;
+  background: var(--line-strong);
+}
+
+@media (max-width: 480px) {
+  .toc-sep {
+    display: none;
+  }
 }
 
 /* Docs page: tighter section rhythm */


### PR DESCRIPTION
## Summary

Reworks the website navigation: Severity never belonged in the top nav, and the CLI reference / setup guides were full pages buried behind a single in-body link.

- **Top nav (all pages):** now `Features · Install · FAQ · Docs · CLI · GitHub · Download` — Severity drops out (the section stays on the landing page), CLI gets a top-level link
- **Active states fixed:** `cli.html` wrongly highlighted *Docs*; subpages now use `class="active"` + `aria-current="page"` on the right link
- **Scroll highlighting revived:** landing nav links were `index.html#features`-style, so the IntersectionObserver in `script.js` never matched — bare `#anchors` make section highlighting work again with no JS changes
- **Docs subnav via chips:** both doc pages open with cross-page chips (*automate & integrate* ↔ *cli reference*), current page filled with accent, then a divider and the in-page section chips
- **Honest anchors on docs.html:** webhooks / script hooks / url scheme / applescript chips previously all jumped to `#automate`; each card now has its own id. Catalog section renamed `#docs` → `#catalog`; "cli & prompt" chip relabeled **setup guides** to match the landing-page link text
- **Footer** gains Docs/CLI links; cache-busters bumped (`style.css?v=4`, `script.js?v=3`)

## Verification

Checked live via Playwright against a local `http.server`:
- All chip anchors resolve on both doc pages; correct nav item highlighted per page
- Scroll-spy highlights Install/FAQ on the landing page as sections pass
- No nav wrap at 760px; mobile hamburger fits all 7 items with no horizontal overflow at 375px
- Light and dark mode chip styles render correctly (token-based)

🤖 Generated with [Claude Code](https://claude.com/claude-code)