### PR TITLE
feat(site): tabbed doc pages

### DIFF
--- a/docs/cli.html
+++ b/docs/cli.html
@@ -18,7 +18,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=4">
+  <link rel="stylesheet" href="style.css?v=5">
 </head>
 <body class="docs-page">
 
@@ -57,7 +57,8 @@
       <nav class="toc-chips" aria-label="Documentation">
         <a href="docs.html" class="toc-chip-page">automate &amp; integrate</a>
         <a href="cli.html" class="toc-chip-page" aria-current="page">cli reference</a>
-        <span class="toc-sep" aria-hidden="true"></span>
+      </nav>
+      <nav class="tab-bar" aria-label="Page sections">
         <a href="#cli-install">install</a>
         <a href="#cli-commands">commands</a>
         <a href="#cli-options">options</a>
@@ -67,7 +68,7 @@
     </div>
   </header>
 
-  <section id="cli-install">
+  <section id="cli-install" class="tab-panel">
     <div class="container">
       <p class="section-label">setup</p>
       <h2>Get <code>statusbar</code> on your PATH</h2>
@@ -122,7 +123,7 @@ statusbar help        # full usage</code></pre>
     </div>
   </section>
 
-  <section id="cli-commands">
+  <section id="cli-commands" class="tab-panel">
     <div class="container">
       <p class="section-label">commands</p>
       <h2>Commands</h2>
@@ -168,7 +169,7 @@ statusbar add https://status.openai.com OpenAI</code></pre>
     </div>
   </section>
 
-  <section id="cli-options">
+  <section id="cli-options" class="tab-panel">
     <div class="container">
       <p class="section-label">options</p>
       <h2>Options</h2>
@@ -190,7 +191,7 @@ statusbar add https://status.openai.com OpenAI</code></pre>
     </div>
   </section>
 
-  <section id="cli-exit">
+  <section id="cli-exit" class="tab-panel">
     <div class="container">
       <p class="section-label">signals</p>
       <h2>Exit codes &amp; glyphs</h2>
@@ -231,7 +232,7 @@ statusbar add https://status.openai.com OpenAI</code></pre>
     </div>
   </section>
 
-  <section id="cli-scoping">
+  <section id="cli-scoping" class="tab-panel">
     <div class="container">
       <p class="section-label">scoping</p>
       <h2>Repo scoping with <code>.statusbar</code></h2>
@@ -278,6 +279,6 @@ Vercel</code></pre>
     </div>
   </footer>
 
-  <script src="script.js?v=3"></script>
+  <script src="script.js?v=4"></script>
 </body>
 </html>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -18,7 +18,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=4">
+  <link rel="stylesheet" href="style.css?v=5">
 </head>
 <body class="docs-page">
 
@@ -57,11 +57,9 @@
       <nav class="toc-chips" aria-label="Documentation">
         <a href="docs.html" class="toc-chip-page" aria-current="page">automate &amp; integrate</a>
         <a href="cli.html" class="toc-chip-page">cli reference</a>
-        <span class="toc-sep" aria-hidden="true"></span>
-        <a href="#webhooks">webhooks</a>
-        <a href="#hooks">script hooks</a>
-        <a href="#url-scheme">url scheme</a>
-        <a href="#applescript">applescript</a>
+      </nav>
+      <nav class="tab-bar" aria-label="Page sections">
+        <a href="#automate">automate</a>
         <a href="#terminal">setup guides</a>
         <a href="#widget">widget</a>
         <a href="#catalog">source catalog</a>
@@ -69,7 +67,7 @@
     </div>
   </header>
 
-  <section id="automate">
+  <section id="automate" class="tab-panel">
     <div class="container">
       <p class="section-label">automate</p>
       <h2>Connect StatusBar to your workflow</h2>
@@ -298,7 +296,7 @@ end tell</code></pre>
     </div>
   </section>
 
-  <section id="terminal">
+  <section id="terminal" class="tab-panel">
     <div class="container">
       <p class="section-label">terminal</p>
       <h2>The CLI and your prompt</h2>
@@ -393,7 +391,7 @@ sketchybar --set "$NAME" label="$(statusbar prompt)"</code></pre>
     </div>
   </section>
 
-  <section id="widget">
+  <section id="widget" class="tab-panel">
     <div class="container">
       <p class="section-label">desktop</p>
       <h2>The widget</h2>
@@ -426,7 +424,7 @@ sketchybar --set "$NAME" label="$(statusbar prompt)"</code></pre>
     </div>
   </section>
 
-  <section id="catalog">
+  <section id="catalog" class="tab-panel">
     <div class="container">
       <p class="section-label">catalog</p>
       <h2>Adding Sources</h2>
@@ -484,6 +482,6 @@ sketchybar --set "$NAME" label="$(statusbar prompt)"</code></pre>
     </div>
   </footer>
 
-  <script src="script.js?v=3"></script>
+  <script src="script.js?v=4"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css?v=4">
+  <link rel="stylesheet" href="style.css?v=5">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -310,6 +310,6 @@ brew install --cask statusbar</code></pre>
     </div>
   </footer>
 
-  <script src="script.js?v=3"></script>
+  <script src="script.js?v=4"></script>
 </body>
 </html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -143,6 +143,7 @@
   // --- Smooth scroll for anchor links ---
   document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
     anchor.addEventListener('click', function (e) {
+      if (this.closest('.tab-bar')) return; // tab clicks swap panels, they don't scroll
       const target = document.querySelector(this.getAttribute('href'));
       if (target) {
         e.preventDefault();
@@ -464,6 +465,76 @@
 
   // Initial render
   renderSources('');
+
+  // --- Content tabs on doc pages ---
+  var tabBar = document.querySelector('.tab-bar');
+  if (tabBar) {
+    var tabLinks = Array.prototype.slice.call(tabBar.querySelectorAll('a[href^="#"]'));
+    var tabPanels = tabLinks.map(function (link) {
+      return document.getElementById(link.getAttribute('href').slice(1));
+    });
+
+    if (tabPanels.length && tabPanels.every(Boolean)) {
+      document.body.classList.add('tabs-js');
+      tabBar.setAttribute('role', 'tablist');
+      tabLinks.forEach(function (link, i) {
+        link.setAttribute('role', 'tab');
+        if (!link.id) link.id = 'tab-' + tabPanels[i].id;
+        tabPanels[i].setAttribute('role', 'tabpanel');
+        tabPanels[i].setAttribute('aria-labelledby', link.id);
+      });
+
+      var activateTab = function (index, setFocus) {
+        tabLinks.forEach(function (link, i) {
+          var selected = i === index;
+          link.classList.toggle('active', selected);
+          link.setAttribute('aria-selected', selected ? 'true' : 'false');
+          link.setAttribute('tabindex', selected ? '0' : '-1');
+          tabPanels[i].classList.toggle('active', selected);
+        });
+        if (setFocus) tabLinks[index].focus();
+      };
+
+      var tabIndexForHash = function (hash) {
+        var target = hash && document.getElementById(hash.slice(1));
+        if (target) {
+          for (var i = 0; i < tabPanels.length; i++) {
+            if (tabPanels[i] === target || tabPanels[i].contains(target)) return i;
+          }
+        }
+        return 0;
+      };
+
+      var routeTabs = function () {
+        var hash = window.location.hash;
+        var index = tabIndexForHash(hash);
+        activateTab(index, false);
+        var target = hash && document.getElementById(hash.slice(1));
+        if (target && target !== tabPanels[index]) {
+          target.scrollIntoView(); // deep link to an element inside the panel
+        }
+      };
+
+      tabLinks.forEach(function (link, i) {
+        link.addEventListener('click', function (e) {
+          e.preventDefault();
+          activateTab(i, false);
+          history.replaceState(null, '', link.getAttribute('href'));
+        });
+        link.addEventListener('keydown', function (e) {
+          var dir = e.key === 'ArrowRight' ? 1 : e.key === 'ArrowLeft' ? -1 : 0;
+          if (!dir) return;
+          e.preventDefault();
+          var next = (i + dir + tabLinks.length) % tabLinks.length;
+          activateTab(next, true);
+          history.replaceState(null, '', tabLinks[next].getAttribute('href'));
+        });
+      });
+
+      window.addEventListener('hashchange', routeTabs);
+      routeTabs();
+    }
+  }
 
   // --- IntersectionObserver for active nav link ---
   const sections = document.querySelectorAll('section[id]');

--- a/docs/style.css
+++ b/docs/style.css
@@ -1501,17 +1501,48 @@ section {
   border-color: var(--accent);
 }
 
-.toc-sep {
-  width: 1px;
-  height: 16px;
-  align-self: center;
-  background: var(--line-strong);
+/* Content tabs on doc pages */
+.tab-bar {
+  display: flex;
+  gap: 4px;
+  margin-top: 28px;
+  border-bottom: 1px solid var(--line-strong);
+  overflow-x: auto;
+  scrollbar-width: none;
 }
 
-@media (max-width: 480px) {
-  .toc-sep {
-    display: none;
-  }
+.tab-bar::-webkit-scrollbar {
+  display: none;
+}
+
+.tab-bar a {
+  font-family: var(--font-mono);
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  padding: 10px 14px;
+  white-space: nowrap;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition: color var(--timing-hover) ease-out, border-color var(--timing-hover) ease-out;
+}
+
+.tab-bar a:hover {
+  color: var(--text-primary);
+}
+
+.tab-bar a.active {
+  color: var(--text-primary);
+  border-bottom-color: var(--accent);
+}
+
+/* With JS enabled only the active panel is shown; without JS the page
+   degrades to all sections stacked with the tab bar as anchor links */
+.tabs-js .tab-panel {
+  display: none;
+}
+
+.tabs-js .tab-panel.active {
+  display: block;
 }
 
 /* Docs page: tighter section rhythm */


### PR DESCRIPTION
## Summary

Follow-up to #37: `docs.html` and `cli.html` become tabbed pages instead of long scrolling ones. The section chips are replaced by an underline-style tab bar in the page header, and each top-level section is a panel shown one at a time — docs gets 4 tabs (automate / setup guides / widget / source catalog), CLI gets 5 (install / commands / options / exit codes & glyphs / repo scoping).

- **Hash-routed:** `docs.html#terminal` opens the setup-guides tab; deep links to elements *inside* a panel (e.g. `#webhooks`) activate the containing tab and scroll to the element; `hashchange` is handled so back/forward work. Tab clicks update the hash via `replaceState` without scrolling.
- **Accessible:** JS applies `role=tablist/tab/tabpanel`, `aria-selected`, roving tabindex, and left/right arrow-key navigation.
- **Progressive:** panel hiding is gated on a `tabs-js` body class added by JS — with JS disabled the pages degrade to the previous stacked layout with the tab bar acting as plain anchor links.
- The smooth-scroll handler now skips tab-bar links; the unused `.toc-sep` divider CSS/markup is removed; cache-busters bumped (`style.css?v=5`, `script.js?v=4`).

## Verification

Checked live via Playwright against a local server:
- One panel visible at a time; correct default tab on both pages
- Clicking tabs swaps panels, updates the hash, and doesn't move scroll position
- Deep links: `#terminal` → setup-guides tab; `#webhooks` → automate tab scrolled to the card
- Interactive source catalog (search/select/export) still works inside its tab
- Arrow keys cycle tabs; `aria-selected` tracks the active tab
- No horizontal page overflow at 375px — the tab bar itself scrolls
- Light and dark mode both render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)